### PR TITLE
Support for Reed Solomon data redundancy 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+os:
+  - linux
+  - osx
+
 go:
   - 1.4
   - 1.5

--- a/backend.go
+++ b/backend.go
@@ -27,9 +27,9 @@ type Backend interface {
 	Close() error
 
 	// LoadChunk loads a single Chunk
-	LoadChunk(chunk Chunk) ([]byte, error)
+	LoadChunk(shasum string, part uint) (*[]byte, error)
 	// StoreChunk stores a single Chunk
-	StoreChunk(chunk Chunk) (size uint64, err error)
+	StoreChunk(shasum string, part uint, data *[]byte) (size uint64, err error)
 
 	// LoadSnapshot loads a snapshot
 	LoadSnapshot(id string) ([]byte, error)

--- a/chunker.go
+++ b/chunker.go
@@ -91,13 +91,7 @@ func processChunk(id int, compress, encrypt bool, password string, dataParts, pa
 		decshasumdata := sha256.Sum256(j.Data)
 		decshasum := hex.EncodeToString(decshasumdata[:])
 
-		pars, err := redundantData(finalData, dataParts, parityParts)
-		if err != nil {
-			panic(err)
-		}
-
 		cd := Chunk{
-			Data:            &pars,
 			DataParts:       uint(dataParts),
 			ParityParts:     uint(parityParts),
 			Size:            len(finalData),
@@ -112,6 +106,16 @@ func processChunk(id int, compress, encrypt bool, password string, dataParts, pa
 		}
 		if !encrypt {
 			cd.Encrypted = EncryptionNone
+		}
+		if parityParts > 0 {
+			pars, err := redundantData(finalData, dataParts, parityParts)
+			if err != nil {
+				panic(err)
+			}
+			cd.Data = &pars
+		} else {
+			cd.DataParts = 1
+			cd.Data = &[][]byte{finalData}
 		}
 
 		results <- cd

--- a/chunker.go
+++ b/chunker.go
@@ -49,13 +49,15 @@ func CompressionText(enum int) string {
 // Chunk stores an encrypted chunk alongside with its metadata
 // MUST BE encrypted
 type Chunk struct {
-	Data            *[]byte `json:"-"`
-	Size            int     `json:"size"`
-	DecryptedShaSum string  `json:"decrypted_sha256"`
-	ShaSum          string  `json:"sha256"`
-	Encrypted       int     `json:"encrypted"`
-	Compressed      int     `json:"compressed"`
-	Num             uint64  `json:"num"`
+	Data            *[][]byte `json:"-"`
+	DataParts       uint      `json:"data_parts"`
+	ParityParts     uint      `json:"parity_parts"`
+	Size            int       `json:"size"`
+	DecryptedShaSum string    `json:"decrypted_sha256"`
+	ShaSum          string    `json:"sha256"`
+	Encrypted       int       `json:"encrypted"`
+	Compressed      int       `json:"compressed"`
+	Num             uint64    `json:"num"`
 }
 
 type inputChunk struct {
@@ -63,7 +65,7 @@ type inputChunk struct {
 	Num  uint64
 }
 
-func processChunk(id int, compress, encrypt bool, password string, jobs <-chan inputChunk, results chan<- Chunk, wg *sync.WaitGroup) {
+func processChunk(id int, compress, encrypt bool, password string, dataParts, parityParts int, jobs <-chan inputChunk, results chan<- Chunk, wg *sync.WaitGroup) {
 	for j := range jobs {
 		//		fmt.Println("\tWorker", id, "processing job", j.Num, len(j.Data))
 
@@ -89,8 +91,15 @@ func processChunk(id int, compress, encrypt bool, password string, jobs <-chan i
 		decshasumdata := sha256.Sum256(j.Data)
 		decshasum := hex.EncodeToString(decshasumdata[:])
 
+		pars, err := redundantData(finalData, dataParts, parityParts)
+		if err != nil {
+			panic(err)
+		}
+
 		cd := Chunk{
-			Data:            &finalData,
+			Data:            &pars,
+			DataParts:       uint(dataParts),
+			ParityParts:     uint(parityParts),
 			Size:            len(finalData),
 			DecryptedShaSum: decshasum,
 			ShaSum:          shasum,
@@ -111,7 +120,7 @@ func processChunk(id int, compress, encrypt bool, password string, jobs <-chan i
 }
 
 // chunkFile divides filename into chunks of 1MiB each
-func chunkFile(filename string, compress, encrypt bool, password string) (chan Chunk, error) {
+func chunkFile(filename string, compress, encrypt bool, password string, dataParts, parityParts int) (chan Chunk, error) {
 	c := make(chan Chunk)
 
 	file, err := os.Open(filename)
@@ -131,7 +140,7 @@ func chunkFile(filename string, compress, encrypt bool, password string) (chan C
 	wg := &sync.WaitGroup{}
 	jobs := make(chan inputChunk)
 	for w := 1; w <= 4; w++ {
-		go processChunk(w, compress, encrypt, password, jobs, c, wg)
+		go processChunk(w, compress, encrypt, password, dataParts, parityParts, jobs, c, wg)
 	}
 
 	wg.Add(int(totalParts))

--- a/decode.go
+++ b/decode.go
@@ -13,7 +13,6 @@ import (
 	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -109,7 +108,7 @@ func loadChunk(repository Repository, chunk Chunk) ([]byte, error) {
 		}
 	}
 
-	return []byte{}, errors.New("Could not reconstruct data")
+	return []byte{}, fmt.Errorf("Could not reconstruct data, got %d out of %d chunks (%d backends missing data)", parsFound, chunk.DataParts, chunk.DataParts-uint(parsFound))
 }
 
 // DecodeArchive restores a single archive to path

--- a/decode.go
+++ b/decode.go
@@ -8,6 +8,7 @@
 package knoxite
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"crypto/sha256"
@@ -18,6 +19,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/klauspost/reedsolomon"
 )
 
 // DecodeSnapshot restores an entire snapshot to dst
@@ -36,6 +39,77 @@ func DecodeSnapshot(repository Repository, snapshot Snapshot, dst string) (prog 
 	}()
 
 	return prog, nil
+}
+
+func loadChunk(repository Repository, chunk Chunk) ([]byte, error) {
+	enc, err := reedsolomon.New(int(chunk.DataParts), int(chunk.ParityParts))
+	if err != nil {
+		return []byte{}, err
+	}
+	pars := make([][]byte, chunk.DataParts+chunk.ParityParts)
+	parsFound := 0
+	parsMissing := 0
+	for i := 0; i < int(chunk.DataParts+chunk.ParityParts); i++ {
+		var cerr error
+		pars[i], cerr = repository.Backend.LoadChunk(chunk, uint(i))
+		if cerr != nil {
+			pars[i] = nil
+			parsMissing++
+			continue
+		}
+		parsFound++
+
+		if parsFound >= int(chunk.DataParts) {
+			var b bytes.Buffer
+			bufWriter := bufio.NewWriter(&b)
+
+			if parsMissing > 0 {
+				err = enc.Reconstruct(pars)
+				if err != nil {
+					continue
+				}
+			}
+			err = enc.Join(bufWriter, pars, chunk.Size)
+			if err != nil {
+				continue
+			}
+			bufWriter.Flush()
+			finalData := b.Bytes()
+
+			if chunk.Encrypted == EncryptionAES {
+				data, err := Decrypt(finalData, repository.Password)
+				if err != nil {
+					return []byte{}, err
+				}
+
+				finalData = data
+			}
+
+			if chunk.Compressed == CompressionGZip {
+				reader := bytes.NewReader(finalData)
+				zipreader, err := gzip.NewReader(reader)
+				if err != nil {
+					return []byte{}, err
+				}
+				defer zipreader.Close()
+				finalData, err = ioutil.ReadAll(zipreader)
+				if err != nil {
+					return []byte{}, err
+				}
+			}
+
+			shasumdata := sha256.Sum256(finalData)
+			shasum := hex.EncodeToString(shasumdata[:])
+
+			if chunk.DecryptedShaSum != shasum {
+				return []byte{}, fmt.Errorf("sha256 mismatch, expected %s got %s", chunk.DecryptedShaSum, shasum)
+			}
+
+			return finalData, nil
+		}
+	}
+
+	return []byte{}, errors.New("Could not reconstruct data")
 }
 
 // DecodeArchive restores a single archive to path
@@ -67,40 +141,9 @@ func DecodeArchive(progress chan Progress, repository Repository, arc ItemData, 
 		for i := int(0); i < parts; i++ {
 			for _, chunk := range arc.Chunks {
 				if int(chunk.Num) == i {
-					finalData, cerr := repository.Backend.LoadChunk(chunk)
+					finalData, cerr := loadChunk(repository, chunk)
 					if cerr != nil {
 						return cerr
-					}
-
-					if chunk.Encrypted == EncryptionAES {
-						data, err := Decrypt(finalData, repository.Password)
-						if err != nil {
-							return err
-						}
-
-						finalData = data
-					}
-
-					if chunk.Compressed == CompressionGZip {
-						reader := bytes.NewReader(finalData)
-						zipreader, err := gzip.NewReader(reader)
-						if err != nil {
-							return err
-						}
-						defer zipreader.Close()
-						finalData, err = ioutil.ReadAll(zipreader)
-						if err != nil {
-							return err
-						}
-					}
-
-					shasumdata := sha256.Sum256(finalData)
-					shasum := hex.EncodeToString(shasumdata[:])
-					prog.Statistics.Size += uint64(len(finalData))
-					prog.Size += uint64(len(finalData))
-
-					if chunk.DecryptedShaSum != shasum {
-						return errors.New("sha256 mismatch")
 					}
 
 					// write/save buffer to disk
@@ -108,9 +151,12 @@ func DecodeArchive(progress chan Progress, repository Repository, arc ItemData, 
 					if ferr != nil {
 						return ferr
 					}
+
+					prog.Statistics.Size += uint64(len(finalData))
+					prog.Size += uint64(len(finalData))
+					progress <- prog
 					// fmt.Printf("Chunk OK: %d bytes, sha256: %s\n", size, chunk.DecryptedShaSum)
 				}
-				progress <- prog
 			}
 		}
 
@@ -142,7 +188,7 @@ func init() {
 
 }
 
-// DecodeArchiveData restores a single archive to path
+// DecodeArchiveData returns the content of a single archive
 func DecodeArchiveData(repository Repository, arc ItemData) (dat []byte, stats Stat, err error) {
 	if arc.Type == File {
 		parts := len(arc.Chunks)
@@ -159,45 +205,15 @@ func DecodeArchiveData(repository Repository, arc ItemData) (dat []byte, stats S
 						continue
 					}
 
-					finalData, err := repository.Backend.LoadChunk(chunk)
-					origData := finalData
-					if err != nil {
-						return dat, stats, err
+					finalData, cerr := loadChunk(repository, chunk)
+					if cerr != nil {
+						return dat, stats, cerr
 					}
 
-					if chunk.Encrypted == EncryptionAES {
-						data, err := Decrypt(finalData, repository.Password)
-						if err != nil {
-							return dat, stats, err
-						}
-
-						finalData = data
-					}
-
-					if chunk.Compressed == CompressionGZip {
-						reader := bytes.NewReader(finalData)
-						zipreader, err := gzip.NewReader(reader)
-						if err != nil {
-							return dat, stats, err
-						}
-						defer zipreader.Close()
-						finalData, err = ioutil.ReadAll(zipreader)
-						if err != nil {
-							return dat, stats, err
-						}
-					}
-
-					shasumdata := sha256.Sum256(finalData)
-					shasum := hex.EncodeToString(shasumdata[:])
-					stats.StorageSize += uint64(len(origData))
+					stats.StorageSize += uint64(len(finalData))
 					stats.Size += uint64(len(finalData))
 
-					if chunk.DecryptedShaSum != shasum {
-						return dat, stats, errors.New("ERROR: sha256 mismatch")
-					}
-
 					dat = append(dat, finalData...)
-
 					cache[chunk.ShaSum] = finalData
 					mutex.Unlock()
 				}
@@ -224,42 +240,12 @@ func readArchiveChunk(repository Repository, arc ItemData, chunkNum uint64) (dat
 				continue
 			}
 
-			finalData, err := repository.Backend.LoadChunk(chunk)
+			finalData, err := loadChunk(repository, chunk)
 			if err != nil {
 				return dat, err
 			}
 
-			if chunk.Encrypted == EncryptionAES {
-				data, err := Decrypt(finalData, repository.Password)
-				if err != nil {
-					return dat, err
-				}
-
-				finalData = data
-			}
-
-			if chunk.Compressed == CompressionGZip {
-				reader := bytes.NewReader(finalData)
-				zipreader, err := gzip.NewReader(reader)
-				if err != nil {
-					return dat, err
-				}
-				defer zipreader.Close()
-				finalData, err = ioutil.ReadAll(zipreader)
-				if err != nil {
-					return dat, err
-				}
-			}
-
-			/*			shasumdata := sha256.Sum256(finalData)
-						shasum := hex.EncodeToString(shasumdata[:])
-
-						if chunk.DecryptedShaSum != shasum {
-							return dat, errors.New("ERROR: sha256 mismatch")
-						}*/
-
 			*dat = append(*dat, finalData...)
-
 			cache[chunk.ShaSum] = finalData
 			mutex.Unlock()
 		}

--- a/knoxite/repository.go
+++ b/knoxite/repository.go
@@ -88,7 +88,13 @@ func (cmd CmdRepository) add(url string) error {
 	}
 	r.Backend.AddBackend(&backend)
 
-	return r.Save()
+	err = r.Save()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Added %s to repository\n", backend.Location())
+
+	return nil
 }
 
 func (cmd CmdRepository) cat() error {

--- a/redundancy.go
+++ b/redundancy.go
@@ -1,0 +1,22 @@
+package knoxite
+
+import "github.com/klauspost/reedsolomon"
+
+func redundantData(finalData []byte, chunks, redundancyChunks int) ([][]byte, error) {
+	enc, err := reedsolomon.New(chunks, redundancyChunks)
+	if err != nil {
+		return [][]byte{}, err
+	}
+
+	pardata, err := enc.Split(finalData)
+	if err != nil {
+		panic(err)
+	}
+
+	err = enc.Encode(pardata)
+	if err != nil {
+		return [][]byte{}, err
+	}
+
+	return pardata, nil
+}

--- a/snapshot.go
+++ b/snapshot.go
@@ -44,7 +44,7 @@ func NewSnapshot(description string) (Snapshot, error) {
 }
 
 // Add adds a path to a Snapshot
-func (snapshot *Snapshot) Add(cwd, path string, repository Repository, compress, encrypt bool) (chan Progress, error) {
+func (snapshot *Snapshot) Add(cwd, path string, repository Repository, compress, encrypt bool, dataParts, parityParts uint) (chan Progress, error) {
 	progress := make(chan Progress)
 
 	go func() {
@@ -61,14 +61,8 @@ func (snapshot *Snapshot) Add(cwd, path string, repository Repository, compress,
 			progress <- newProgress(&id)
 
 			if isRegularFile(id.FileInfo) {
-				dataParts := int(math.Max(1, float64(len(repository.Backend.Backends))))
-				parityParts := 0
-
-				if len(repository.Backend.Backends) > 1 {
-					// If there are multiple storage backends, divide the data among them
-					parityParts = int(math.Max(1, float64(dataParts)/3.0))
-				}
-				chunkchan, err := chunkFile(id.AbsPath, compress, encrypt, repository.Password, dataParts, parityParts)
+				dataParts = uint(math.Max(1, float64(dataParts)))
+				chunkchan, err := chunkFile(id.AbsPath, compress, encrypt, repository.Password, int(dataParts), int(parityParts))
 				if err != nil {
 					panic(err)
 				}

--- a/storage_local.go
+++ b/storage_local.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 )
 
 const (
@@ -46,26 +47,26 @@ func (backend *StorageLocal) Description() string {
 }
 
 // LoadChunk loads a Chunk from disk
-func (backend *StorageLocal) LoadChunk(chunk Chunk) ([]byte, error) {
-	fileName := filepath.Join(backend.Path, "chunks", chunk.ShaSum)
+func (backend *StorageLocal) LoadChunk(shasum string, part uint) (*[]byte, error) {
+	fileName := filepath.Join(backend.Path, "chunks", shasum+"."+strconv.FormatUint(uint64(part), 10))
 	b := []byte{}
 	b, err := ioutil.ReadFile(fileName)
-	return b, err
+	return &b, err
 }
 
 // StoreChunk stores a single Chunk on disk
-func (backend *StorageLocal) StoreChunk(chunk Chunk) (size uint64, err error) {
-	fileName := filepath.Join(backend.Path, "chunks", chunk.ShaSum)
+func (backend *StorageLocal) StoreChunk(shasum string, part uint, data *[]byte) (size uint64, err error) {
+	fileName := filepath.Join(backend.Path, "chunks", shasum+"."+strconv.FormatUint(uint64(part), 10))
 	if _, err = os.Stat(fileName); err == nil {
 		// Chunk is already stored
 		return 0, nil
 	}
 
-	err = ioutil.WriteFile(fileName, *chunk.Data, 0600)
+	err = ioutil.WriteFile(fileName, *data, 0600)
 	if err != nil {
 		fmt.Println(err)
 	}
-	return uint64(len(*chunk.Data)), err
+	return uint64(len(*data)), err
 }
 
 // LoadSnapshot loads a snapshot


### PR DESCRIPTION
knoxite can now store redundant parity data which allows for failure tolerance. This can be controlled with the "-t" parameter of the store command, e.g.:

"knoxite -r ... -t 2 store abcdef12 somefile"