### PR TITLE
Fixed infinite DeletePath loop for FTP backends reporting dot folders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 gobuild_args: -v -tags ci
+dist: precise
 sudo: required
 
 os:

--- a/storage/ftp/storage_ftp.go
+++ b/storage/ftp/storage_ftp.go
@@ -11,7 +11,6 @@ package ftp
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"net/url"
@@ -175,13 +174,15 @@ func (backend *StorageFTP) DeleteFile(path string) error {
 
 // DeletePath deletes a directory including all its content from ftp
 func (backend *StorageFTP) DeletePath(path string) error {
-	fmt.Println("Deleting path", path)
 	list, err := backend.ftp.List(path)
 	if err != nil {
 		return err
 	}
 	for _, l := range list {
 		if l.Type == ftp.EntryTypeFolder {
+			if len(l.Name) == 0 || strings.HasPrefix(l.Name, ".") {
+				continue
+			}
 			err = backend.DeletePath(filepath.Join(path, l.Name))
 			if err != nil {
 				return err


### PR DESCRIPTION
Something weird going on with pureftpd on trusty. We'll stick to precise as long as we can and I managed to investigate the situation. Probably just needs changing the FTP test URL ton include the full canonical path.