### PR TITLE
Disable Dropbox module as their old API has been deactivated

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 
 	_ "github.com/knoxite/knoxite/storage/amazons3"
 	_ "github.com/knoxite/knoxite/storage/backblaze"
-	_ "github.com/knoxite/knoxite/storage/dropbox"
+	// _ "github.com/knoxite/knoxite/storage/dropbox"
 	_ "github.com/knoxite/knoxite/storage/ftp"
 	_ "github.com/knoxite/knoxite/storage/http"
 )


### PR DESCRIPTION
We'll have to switch to https://github.com/dropbox/dropbox-sdk-go-unofficial/