### PR TITLE
Optional environment variables for repository and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ $ ./knoxite -r /tmp/knoxite mount [snapshot ID] /mnt
 
 ### Backup. No more excuses.
 
+## Optional environment variables
+Optionally you can set the `KNOXITE_REPOSITORY` and `KNOXITE_PASSWORD` environment
+variables to provide default settings for when no options have been passed to `knoxite`.
+
 ## Development
 
 API docs can be found [here](http://godoc.org/github.com/knoxite/knoxite).

--- a/main.go
+++ b/main.go
@@ -54,6 +54,9 @@ func main() {
 	RootCmd.PersistentFlags().StringVarP(&globalOpts.Repo, "repo", "r", "", "Repository directory to backup to/restore from (default: current working dir)")
 	RootCmd.PersistentFlags().StringVarP(&globalOpts.Password, "password", "p", "", "Password to use for data encryption")
 
+	globalOpts.Repo = os.Getenv("KNOXITE_REPOSITORY")
+	globalOpts.Password = os.Getenv("KNOXITE_PASSWORD")
+
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)


### PR DESCRIPTION
Knoxite now reads out the `KNOXITE_REPOSITORY` and `KNOXITE_PASSWORD`
environment variables in case no options have been provided in the cli.
This helps to shorten the knoxite command like this:
```sh
$ export KNOXITE_REPOSITORY="/tmp/example"
$ export KNOXITE_PASSWORD="mysupersecret"
$ knoxite repo init
Created new repository at /tmp/example
```
Solves #47 

Also mentioned these variables in the README.md.