### PR TITLE
Pass the dropbox access token as user

### DIFF
--- a/storage/dropbox/storage_dropbox.go
+++ b/storage/dropbox/storage_dropbox.go
@@ -32,14 +32,15 @@ func init() {
 
 // NewBackend returns a StorageDropbox backend
 func (*StorageDropbox) NewBackend(u url.URL) (knoxite.Backend, error) {
-	pw, pwexist := u.User.Password()
-	if !pwexist {
-		return &StorageDropbox{}, knoxite.ErrInvalidPassword
+	user := u.User.Username()
+	if user == "" {
+		return &StorageDropbox{}, knoxite.ErrInvalidUsername
+
 	}
 
 	backend := StorageDropbox{
 		url:   u,
-		dropy: dropy.New(dropbox.New(dropbox.NewConfig(pw))),
+		dropy: dropy.New(dropbox.New(dropbox.NewConfig(user))),
 	}
 
 	storageDB, err := knoxite.NewStorageFilesystem(u.Path, &backend)


### PR DESCRIPTION
The dropbox access token is now passed as user so you wont need to separate
password and user with a `:` anymore. Using the backend URL now looks like this:

```
./knoxite -r dropbox://$KEY@dropbox.com/$PATH
```