### PR TITLE
WebDav Storage Backend (Support for Nextcloud/Owncloud)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
+	github.com/studio-b12/gowebdav v0.0.0-20200303150724-9380631c29a1
 	github.com/t3rm1n4l/go-mega v0.0.0-20200117211730-79a813bb328d
 	github.com/tj/go-dropbox v0.0.0-20171107035848-42dd2be3662d
 	github.com/tj/go-dropy v0.0.0-20151223190506-225699a12156

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/studio-b12/gowebdav v0.0.0-20200303150724-9380631c29a1 h1:TPyHV/OgChqNcnYqCoCvIFjR9TU60gFXXBKnhOBzVEI=
+github.com/studio-b12/gowebdav v0.0.0-20200303150724-9380631c29a1/go.mod h1:gCcfDlA1Y7GqOaeEKw5l9dOGx1VLdc/HuQSlQAaZ30s=
 github.com/t3rm1n4l/go-mega v0.0.0-20200117211730-79a813bb328d h1:GsRmok9VXIEc5B6SmRWuuO9hx4x2YBqFqgOXGt9Xs94=
 github.com/t3rm1n4l/go-mega v0.0.0-20200117211730-79a813bb328d/go.mod h1:XWL4vDyd3JKmJx+hZWUVgCNmmhZ2dTBcaNDcxH465s0=
 github.com/tj/go-dropbox v0.0.0-20171107035848-42dd2be3662d h1:kc+jLVc4Ivy9I77bYXJ1f2ZTAPInUxw7W/bqKW43g6Q=
@@ -112,12 +114,16 @@ golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876 h1:sKJQZMuxjOAR/Uo2LBfU90onWEf1dF4C+0hPJCc9Mpc=
 golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190130150945-aca44879d564/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -127,6 +133,9 @@ golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20200113040837-eac381796e91 h1:OOkytthzFBKHY5EfEgLUabprb0LtJVkQtNxAQ02+UE4=
+golang.org/x/tools v0.0.0-20200113040837-eac381796e91/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.51.1 h1:GyboHr4UqMiLUybYjd22ZjQIKEJEpgtLXtuGbR21Oho=

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/knoxite/knoxite/storage/http"
 	_ "github.com/knoxite/knoxite/storage/mega"
 	_ "github.com/knoxite/knoxite/storage/sftp"
+	_ "github.com/knoxite/knoxite/storage/webdav"
 )
 
 // GlobalOptions holds all those options that can be set for every command

--- a/storage/webdav/storage_webdav.go
+++ b/storage/webdav/storage_webdav.go
@@ -1,0 +1,127 @@
+package webdav
+
+/*
+ * knoxite
+ *     Copyright (c) 2020, Fabian Siegel <fabians1999@gmail.com>
+ *
+ *   For license see LICENSE
+ */
+
+import (
+	"errors"
+	"net/url"
+
+	"github.com/studio-b12/gowebdav"
+
+	knoxite "github.com/knoxite/knoxite/lib"
+)
+
+//StorageWebDav stores data on a WebDav Server
+type StorageWebDav struct {
+	URL    url.URL
+	Client *gowebdav.Client
+	knoxite.StorageFilesystem
+}
+
+// Error declaration
+var (
+	ErrInvalidAuthentication = errors.New("Wrong Username or Password")
+)
+
+func init() {
+	knoxite.RegisterBackendFactory(&StorageWebDav{})
+}
+
+// NewBackend returns a StorageWebDav backend
+func (*StorageWebDav) NewBackend(u url.URL) (knoxite.Backend, error) {
+	u0, _ := url.Parse(u.String())
+	if u0.Scheme == "webdav" {
+		u0.Scheme = "http"
+	} else if u0.Scheme == "webdavs" {
+		u0.Scheme = "https"
+	}
+
+	userinfo := u.User
+	username := userinfo.Username()
+	passwd, _ := userinfo.Password()
+
+	webdavClient := gowebdav.NewClient(u0.String(), username, passwd)
+	storage := StorageWebDav{
+		URL:    u,
+		Client: webdavClient,
+	}
+
+	storagedav, err := knoxite.NewStorageFilesystem("", &storage)
+	storage.StorageFilesystem = storagedav
+	if err != nil {
+		return &StorageWebDav{}, err
+	}
+
+	return &storage, nil
+
+}
+
+// Location returns the type and location of the repository
+func (backend *StorageWebDav) Location() string {
+	return backend.URL.String()
+}
+
+// Close - We do not need to Close this backend
+func (backend *StorageWebDav) Close() error {
+	return nil
+}
+
+// Protocols returns the Protocol Schemes supported by this backend
+func (backend *StorageWebDav) Protocols() []string {
+	// Those protocols are not offical protocols, but because webdav uses http, and the
+	// http backend already exists, we have to use webdav(s)
+	// This protocol scheme is also used by file explorers like dolphin
+	return []string{"webdav", "webdavs"}
+}
+
+// Description returns a user-friendly description for this backend
+func (backend *StorageWebDav) Description() string {
+	return "WebDav Storage (Supports {Own/Next}Cloud)"
+}
+
+// AvailableSpace is not available (yet?)
+func (backend *StorageWebDav) AvailableSpace() (uint64, error) {
+	// TODO: This is actually possible, but im leaving it out for now
+	return uint64(0), knoxite.ErrAvailableSpaceUnknown
+}
+
+// CreatePath creates a path on the remote
+func (backend *StorageWebDav) CreatePath(path string) error {
+	return backend.Client.MkdirAll(path, 0755)
+}
+
+// DeleteFile deletes a remote file
+func (backend *StorageWebDav) DeleteFile(path string) error {
+	return backend.Client.Remove(path)
+}
+
+// DeletePath deletes a directory and its contents
+func (backend *StorageWebDav) DeletePath(path string) error {
+	return backend.Client.Remove(path)
+}
+
+// ReadFile reads the file
+func (backend *StorageWebDav) ReadFile(path string) ([]byte, error) {
+	return backend.Client.Read(path)
+}
+
+// WriteFile writes a file
+func (backend *StorageWebDav) WriteFile(path string, data []byte) (size uint64, err error) {
+	err = backend.Client.Write(path, data, 0644)
+	return uint64(len(data)), err
+}
+
+// Stat returns the file size by using the backends Stat function
+func (backend *StorageWebDav) Stat(path string) (uint64, error) {
+	stat, err := backend.Client.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(stat.Size()), nil
+
+}


### PR DESCRIPTION
I added a storage backend for webdav to support owncloud/nextcloud.
However, this should also work with any webdav server.

This PR is still kind of "Work In Progress", as we still need to set up configure a test suite. Docs would be helpful as well.

Commits:
 - knoxite-66 - Added webdav storage backend