### PR TITLE
-c, --exclude flag for restore command

### DIFF
--- a/lib/decode.go
+++ b/lib/decode.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -64,11 +65,28 @@ func (e *DataReconstructionError) Error() string {
 }
 
 // DecodeSnapshot restores an entire snapshot to dst
-func DecodeSnapshot(repository Repository, snapshot *Snapshot, dst string) (prog chan Progress, err error) {
+func DecodeSnapshot(repository Repository, snapshot *Snapshot, dst string, excludes []string) (prog chan Progress, err error) {
 	prog = make(chan Progress)
 	go func() {
 		for _, arc := range snapshot.Archives {
 			path := filepath.Join(dst, arc.Path)
+
+			match := false
+			for _, exclude := range excludes {
+				match, err = filepath.Match(strings.ToLower(exclude), strings.ToLower(arc.Path))
+				if err != nil {
+					fmt.Println("Invalid exclude filter:", exclude)
+					return
+				}
+				if match {
+					break
+				}
+			}
+
+			if match {
+				continue
+			}
+
 			err := DecodeArchive(prog, repository, *arc, path)
 			if err != nil {
 				p := newProgressError(err)


### PR DESCRIPTION
The restore command now supports a flag in order to exclude folders to restore
from a snapshot.

You can use the syntax from golangs [filepath.Match](https:/golang.org/pkg/path/filepath/#Match) but you'll have to escape it in your shell like this:
```
knoxite restore -x ~/Test/\* latest /destination
```

Note: A folder which has been excluded like this still gets created but will be empty
