### PR TITLE
Test the exclude option on snapshot create/decode

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -66,14 +66,15 @@ func (e *DataReconstructionError) Error() string {
 }
 
 // DecodeSnapshot restores an entire snapshot to dst.
-func DecodeSnapshot(repository Repository, snapshot *Snapshot, dst string, excludes []string) (prog chan Progress, err error) {
-	prog = make(chan Progress)
+func DecodeSnapshot(repository Repository, snapshot *Snapshot, dst string, excludes []string) (chan Progress, error) {
+	prog := make(chan Progress)
 	go func() {
 		for _, arc := range snapshot.Archives {
 			path := filepath.Join(dst, arc.Path)
 
 			match := false
 			for _, exclude := range excludes {
+				var err error
 				match, err = filepath.Match(strings.ToLower(exclude), strings.ToLower(arc.Path))
 				if err != nil {
 					fmt.Println("Invalid exclude filter:", exclude)

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/minio/highwayhash v1.0.0
 	github.com/minio/minio-go v6.0.14+incompatible
 	github.com/mmcloughlin/avo v0.0.0-20200523190732-4439b6b2c061 // indirect
+	github.com/muesli/combinator v0.3.0
 	github.com/muesli/crunchy v0.4.0
 	github.com/muesli/go-app-paths v0.2.1
 	github.com/muesli/goprogressbar v0.0.0-20190807022807-e540249d2ac1

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mmcloughlin/avo v0.0.0-20200523190732-4439b6b2c061 h1:UCU8+cLbbvyxi0sQ9fSeoEhZgvrrD9HKMtX6Gmc1vk8=
 github.com/mmcloughlin/avo v0.0.0-20200523190732-4439b6b2c061/go.mod h1:wqKykBG2QzQDJEzvRkcS8x6MiSJkF52hXZsXcjaB3ls=
+github.com/muesli/combinator v0.3.0 h1:SZDuRzzwmVPLkbOzbhGzBTwd5+Y6aFN4UusOW2azrNA=
+github.com/muesli/combinator v0.3.0/go.mod h1:ttPegJX0DPQaGDtJKMInIP6Vfp5pN8RX7QntFCcpy18=
 github.com/muesli/crunchy v0.4.0 h1:qdiml8gywULHBsztiSAf6rrE6EyuNasNKZ104mAaahM=
 github.com/muesli/crunchy v0.4.0/go.mod h1:9k4x6xdSbb7WwtAVy0iDjaiDjIk6Wa5AgUIqp+HqOpU=
 github.com/muesli/go-app-paths v0.2.1 h1:Qi+2igkDX2aPqyRddp7P0sMQIBwBqhkfQfNcjdGjL6Y=

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -1,6 +1,7 @@
 /*
  * knoxite
  *     Copyright (c) 2016-2018, Christian Muehlhaeuser <muesli@gmail.com>
+ *     Copyright (c) 2020, Nicolas Martin <penguwin@penguwin.eu>
  *
  *   For license see LICENSE
  */
@@ -15,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/minio/highwayhash"
+	"github.com/muesli/combinator"
 )
 
 func hashFile(path string) (string, error) {
@@ -36,19 +38,39 @@ func hashFile(path string) (string, error) {
 func TestSnapshotCreate(t *testing.T) {
 	testPassword := "this_is_a_password"
 
-	tests := []struct {
-		compression uint16
-		parityParts uint
-	}{
-		{CompressionNone, 0},
-		{CompressionFlate, 0},
-		{CompressionGZip, 0},
-		{CompressionLZMA, 0},
-		{CompressionZlib, 0},
-		{CompressionZstd, 0},
-		{CompressionNone, 1},
-		{CompressionGZip, 1},
+	type testOptions struct {
+		Compression     uint16
+		ParityParts     uint
+		ExcludesStore   []string
+		ExcludesRestore []string
 	}
+	testData := struct {
+		Compression     []uint16
+		ParityParts     []uint
+		ExcludesStore   [][]string
+		ExcludesRestore [][]string
+	}{
+		Compression: []uint16{CompressionNone, CompressionFlate, CompressionGZip, CompressionLZMA, CompressionZstd},
+		ParityParts: []uint{0, 1},
+		ExcludesStore: [][]string{
+			{},
+			{"snapshot.go"},
+			{"snapshot_test.go"},
+			{"snapshot.go", "snapshot_test.go"}},
+		ExcludesRestore: [][]string{
+			{},
+			{"snapshot.go"},
+			{"snapshot_test.go"},
+			{"snapshot.go", "snapshot_test.go"}},
+	}
+
+	var tests []testOptions
+	err := combinator.Generate(&tests, testData)
+	if err != nil {
+		t.Errorf("Failed to generate all testcases: %v", err)
+		return
+	}
+
 	for _, tt := range tests {
 		dir, err := ioutil.TempDir("", "knoxite")
 		if err != nil {
@@ -90,7 +112,7 @@ func TestSnapshotCreate(t *testing.T) {
 				t.Errorf("Failed getting working dir: %s", err)
 				return
 			}
-			progress := snapshot.Add(wd, []string{"snapshot_test.go", "snapshot.go"}, []string{}, r, &index, tt.compression, EncryptionAES, 1, tt.parityParts)
+			progress := snapshot.Add(wd, []string{"snapshot_test.go", "snapshot.go"}, tt.ExcludesStore, r, &index, tt.Compression, EncryptionAES, 1, tt.ParityParts)
 			for p := range progress {
 				if p.Error != nil {
 					t.Errorf("Failed adding to snapshot: %s", p.Error)
@@ -114,6 +136,16 @@ func TestSnapshotCreate(t *testing.T) {
 			if err != nil {
 				t.Errorf("Failed saving chunk-index: %s", err)
 				return
+			}
+
+			// Check if we have excluded all the paths in tt.excludes
+			for _, v := range snapshot.Archives {
+				for _, e := range tt.ExcludesStore {
+					if e == v.Path {
+						t.Errorf("Failed excluding specified files from snapshot store operation: %s", e)
+						continue
+					}
+				}
 			}
 
 			snapshotOriginal = snapshot
@@ -156,7 +188,7 @@ func TestSnapshotCreate(t *testing.T) {
 			}
 			defer os.RemoveAll(targetdir)
 
-			progress, err := DecodeSnapshot(r, snapshot, targetdir, []string{})
+			progress, err := DecodeSnapshot(r, snapshot, targetdir, tt.ExcludesRestore)
 			if err != nil {
 				t.Errorf("Failed restoring snapshot: %s", err)
 				return
@@ -169,6 +201,26 @@ func TestSnapshotCreate(t *testing.T) {
 
 			for i, archive := range snapshot.Archives {
 				file1 := filepath.Join(targetdir, archive.Path)
+
+				// Check if the file is a (successfully) excluded one
+				isExcluded := false
+				for _, excl := range tt.ExcludesRestore {
+					excludedFile := filepath.Join(targetdir, excl)
+
+					if _, err := os.Stat(excludedFile); os.IsNotExist(err) {
+						if excludedFile == file1 {
+							isExcluded = true
+							break
+						}
+					} else if err != nil { // Some other error occured
+						t.Errorf("Failed to stat file %s: %v", excl, err)
+						continue
+					}
+				}
+				if isExcluded {
+					continue
+				}
+
 				hash1, err := hashFile(file1)
 				if err != nil {
 					t.Errorf("Failed generating shasum for %s: %s", file1, err)


### PR DESCRIPTION
Testing the exclude option in `TestSnapshotCreate` should bring cover the following
commands:
- store
- restore
- clone

This pr should resolve #82 