### PR TITLE
Make repository password independent of the encryption key

### DIFF
--- a/chunkindex.go
+++ b/chunkindex.go
@@ -33,7 +33,7 @@ func OpenChunkIndex(repository *Repository) (ChunkIndex, error) {
 	}
 	b, err := repository.backend.LoadChunkIndex()
 	if err == nil {
-		pipe, errp := NewDecodingPipeline(CompressionLZMA, EncryptionAES, repository.password)
+		pipe, errp := NewDecodingPipeline(CompressionLZMA, EncryptionAES, repository.Key)
 		if errp != nil {
 			return index, errp
 		}
@@ -59,7 +59,7 @@ func OpenChunkIndex(repository *Repository) (ChunkIndex, error) {
 
 // Save writes a chunk-index
 func (index *ChunkIndex) Save(repository *Repository) error {
-	pipe, err := NewEncodingPipeline(CompressionLZMA, EncryptionAES, repository.password)
+	pipe, err := NewEncodingPipeline(CompressionLZMA, EncryptionAES, repository.Key)
 	if err != nil {
 		return err
 	}

--- a/decode.go
+++ b/decode.go
@@ -101,7 +101,7 @@ func DecodeSnapshot(repository Repository, snapshot *Snapshot, dst string, exclu
 }
 
 func decodeChunk(repository Repository, archive Archive, chunk Chunk, b []byte) ([]byte, error) {
-	pipe, err := NewDecodingPipeline(archive.Compressed, archive.Encrypted, repository.password)
+	pipe, err := NewDecodingPipeline(archive.Compressed, archive.Encrypted, repository.Key)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/snapshot.go
+++ b/snapshot.go
@@ -119,7 +119,7 @@ func (snapshot *Snapshot) Add(cwd string, paths []string, excludes []string, rep
 
 			if archive.Type == File {
 				dataParts = uint(math.Max(1, float64(dataParts)))
-				chunkchan, err := chunkFile(archive.Path, compress, encrypt, repository.password, int(dataParts), int(parityParts))
+				chunkchan, err := chunkFile(archive.Path, compress, encrypt, repository.Key, int(dataParts), int(parityParts))
 				if err != nil {
 					if os.IsNotExist(err) {
 						// if this file has already been deleted before we could backup it, we can gracefully ignore it and continue
@@ -200,7 +200,7 @@ func openSnapshot(id string, repository *Repository) (*Snapshot, error) {
 	if err != nil {
 		return &snapshot, err
 	}
-	pipe, err := NewDecodingPipeline(CompressionLZMA, EncryptionAES, repository.password)
+	pipe, err := NewDecodingPipeline(CompressionLZMA, EncryptionAES, repository.Key)
 	if err != nil {
 		return &snapshot, err
 	}
@@ -210,7 +210,7 @@ func openSnapshot(id string, repository *Repository) (*Snapshot, error) {
 
 // Save writes a snapshot's metadata
 func (snapshot *Snapshot) Save(repository *Repository) error {
-	pipe, err := NewEncodingPipeline(CompressionLZMA, EncryptionAES, repository.password)
+	pipe, err := NewEncodingPipeline(CompressionLZMA, EncryptionAES, repository.Key)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I added the change password functionality for repositories.
Knoxite now uses two different passwords.
- Key: for encryption of the data (will be stored in encrypted repo file
- password: for encryption of the repository file (which holds the Key), can be changed from now on
The repository version was increased to 4.
I also implemented a migrate function to automatically migrate repositories from v3 to v4 to ensure downwards-compatibility.

Closes #68 