### PR TITLE
Fix Mega tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -70,6 +70,12 @@ jobs:
           KNOXITE_AZURE_FILE_URL: ${{ secrets.KNOXITE_AZURE_FILE_URL }}
         run: go test -v -count=1 -tags "ci backend" -covermode atomic -coverprofile=azure.cov ./storage/azure
         if: matrix.go-version == '1.14.x' && matrix.platform == 'ubuntu-latest' && github.event_name == 'push'
+      
+      - name: Storage Mega Backend Tests
+        env:
+          KNOXITE_MEGA_URL: ${{ secrets.KNOXITE_MEGA_URL }}
+        run: go test -v -count=1 -tags "ci backend" -covermode atomic -coverprofile=mega.cov ./storage/mega
+        if: matrix.go-version == '1.14.x' && matrix.platform == 'ubuntu-latest' && github.event_name == 'push'
 
       - name: Storage Backblaze B2 Backend Tests
         env:

--- a/storage/mega/mega_test.go
+++ b/storage/mega/mega_test.go
@@ -1,0 +1,86 @@
+// +build backend
+
+/*
+ * knoxite
+ *     Copyright (c) 2020, Christian Muehlhaeuser <muesli@gmail.com>
+ *     Copyright (c) 2020, Nicolas Martin <penguwin@penguwin.eu>
+ *
+ *   For license see LICENSE
+ */
+package mega
+
+import (
+	"os"
+	"testing"
+
+	"github.com/knoxite/knoxite/storage"
+)
+
+func TestMain(m *testing.M) {
+	// create a random bucket name to avoid collisions
+	rnd := storage.RandomSuffix()
+
+	megaurl := os.Getenv("KNOXITE_MEGA_URL")
+	if len(megaurl) == 0 {
+		panic("no backend configured")
+	}
+
+	backendTest = &storage.BackendTest{
+		URL:         megaurl + rnd,
+		Protocols:   []string{"mega"},
+		Description: "mega.nz storage",
+		TearDown: func(tb *storage.BackendTest) {
+			db := tb.Backend.(*MegaStorage)
+			err := db.DeleteFile(db.Path)
+			if err != nil {
+				panic(err)
+			}
+		},
+	}
+
+	storage.RunBackendTester(backendTest, m)
+}
+
+var (
+	backendTest *storage.BackendTest
+)
+
+func TestStorageNewBackend(t *testing.T) {
+	backendTest.NewBackendTest(t)
+}
+
+func TestStorageLocation(t *testing.T) {
+	backendTest.LocationTest(t)
+}
+
+func TestStorageProtocols(t *testing.T) {
+	backendTest.ProtocolsTest(t)
+}
+
+func TestStorageDescription(t *testing.T) {
+	backendTest.DescriptionTest(t)
+}
+
+func TestStorageInitRepository(t *testing.T) {
+	backendTest.InitRepositoryTest(t)
+}
+
+func TestStorageSaveRepository(t *testing.T) {
+	backendTest.SaveRepositoryTest(t)
+}
+
+func TestAvailableSpace(t *testing.T) {
+	backendTest.AvailableSpaceTest(t)
+}
+
+func TestStorageSaveSnapshot(t *testing.T) {
+	backendTest.SaveSnapshotTest(t)
+}
+
+func TestStorageStoreChunk(t *testing.T) {
+	backendTest.StoreChunkTest(t)
+}
+
+func TestStorageDeleteChunk(t *testing.T) {
+	backendTest.DeleteChunkTest(t)
+}


### PR DESCRIPTION
Fix mega tests by using a copy of the data for the upload method of the mega library, which overrides the data instead of using a copy.
We could create a PR at github.com/t3rm1n4l/go-mega to fix this issue and remove our workaround after that.