### PR TITLE
Expand tilde to the users home directory

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"os/user"
 	"path/filepath"
 
 	gap "github.com/muesli/go-app-paths"
@@ -82,6 +83,24 @@ func (c *Config) SetURL(u string) error {
 	url, err := url.Parse(u)
 	if err != nil {
 		return err
+	}
+
+	// Expand tilde to the users home directory
+	// This is needed in case the shell is unable to expand the path to the users
+	// home directory for inputs like these:
+	// crypto://password@~/path/to/config
+	// NOTE: - url.Parse() will interpret `~` as the Host Element of the URL in
+	//         this case.
+	//       - Using filepath.Abs() won't work as it will interpret `~` as the
+	//         name of a regular folder.
+	if url.Host == "~" {
+		usr, err := user.Current()
+		if err != nil {
+			return err
+		}
+
+		url.Path = filepath.Join(usr.HomeDir, url.Path)
+		url.Host = ""
 	}
 
 	c.url = url


### PR DESCRIPTION
The setURL() method will now correctly expand the tilde to the current users
home directory for inputs like this:
```
crypto://password@~/path/to/file
```

Before this change the tilde symbol got interpreted as a normal directory name.