### PR TITLE
Add linter workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: lint
+on:
+  push:
+  pull_request:
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.30
+          # Optional: golangci-lint command line arguments.
+          args: --issues-exit-code=0
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,10 @@
 run:
   tests: false
 
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
 linters:
   enable:
     - bodyclose


### PR DESCRIPTION
Use golangci-lint for linting new pushes & PRs. Soft-fails for now.