### PR TITLE
Adding SpaceUnlimited error in backend.go

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -64,10 +64,11 @@ type Backend interface {
 
 // Error declarations
 var (
-	ErrRepositoryExists      = errors.New("Repository seems to already exist")
-	ErrInvalidRepositoryURL  = errors.New("Invalid repository url specified")
-	ErrAvailableSpaceUnknown = errors.New("Available space is unknown or undefined")
-	ErrInvalidUsername       = errors.New("Username wrong or missing")
+	ErrRepositoryExists        = errors.New("Repository seems to already exist")
+	ErrInvalidRepositoryURL    = errors.New("Invalid repository url specified")
+	ErrAvailableSpaceUnknown   = errors.New("Available space is unknown or undefined")
+	ErrAvailableSpaceUnlimited = errors.New("Available space is unlimited")
+	ErrInvalidUsername         = errors.New("Username wrong or missing")
 
 	backends = []BackendFactory{}
 )

--- a/storage/backblaze/backblaze.go
+++ b/storage/backblaze/backblaze.go
@@ -102,7 +102,7 @@ func (backend *BackblazeStorage) Description() string {
 // AvailableSpace returns the free space on this backend.
 func (backend *BackblazeStorage) AvailableSpace() (uint64, error) {
 	// Currently not supported
-	return 0, knoxite.ErrAvailableSpaceUnknown
+	return 0, knoxite.ErrAvailableSpaceUnlimited
 }
 
 // LoadChunk loads a Chunk from backblaze.

--- a/storage/backendtester.go
+++ b/storage/backendtester.go
@@ -117,7 +117,7 @@ func (b *BackendTest) SaveRepositoryTest(t *testing.T) {
 
 func (b *BackendTest) AvailableSpaceTest(t *testing.T) {
 	space, err := b.Backend.AvailableSpace()
-	if err != nil && err != knoxite.ErrAvailableSpaceUnknown {
+	if err != nil && err != knoxite.ErrAvailableSpaceUnknown && err != knoxite.ErrAvailableSpaceUnlimited {
 		t.Errorf("%s: expected available space information, got %s", b.Description, err)
 	}
 	if err == nil && space <= 0 {

--- a/storage/googlecloud/gcloud.go
+++ b/storage/googlecloud/gcloud.go
@@ -34,9 +34,10 @@ func init() {
 	knoxite.RegisterStorageBackend(&GoogleCloudStorage{})
 }
 
-// NewBackend returns a GoogleCloudStorage backend.
-// To create a storage client we need either the path to a credential JSON file set via the environment variable GOOGLE_APPLICATION_CREDENTIALS="[PATH]"
-// or the path to the JSON file passed via the user parameter of the URL scheme.
+// NewBackend returns a GoogleCloudStorage backend
+// to create a storage client we need either the path to a credential JSON file set
+// via the environment variable GOOGLE_APPLICATION_CREDENTIALS="[PATH]"
+// or the path to the JSON file passed via the user parameter of the URL scheme
 func (*GoogleCloudStorage) NewBackend(URL url.URL) (knoxite.Backend, error) {
 	var credentialsPath string
 
@@ -66,17 +67,20 @@ func (*GoogleCloudStorage) NewBackend(URL url.URL) (knoxite.Backend, error) {
 		return &GoogleCloudStorage{}, knoxite.ErrInvalidRepositoryURL
 	}
 
-	// we can have a bucket handle even if the bucket doesn't exist yet, so we check if we can access bucket attributes
+	// we can have a bucket handle even if the bucket doesn't exist yet
+	// so we check if we can access bucket attributes
 	bucket := client.Bucket(slicedPath[1])
 	_, err = bucket.Attrs(ctx)
 	if err != nil {
 		return &GoogleCloudStorage{}, err
 	}
 
-	// we can have an object handle even if the object doesn't exist yet, so we check if we can access object attributes
+	// we can have an object handle even if the object doesn't exist yet
+	// so we check if we can access object attributes
 	folder := bucket.Object(folderPath)
 	_, err = folder.Attrs(ctx)
-	// when the repository folder does not exist yet it will be automatically created when initially writing the repository files
+	// when the repository folder does not exist yet it will be automatically created
+	// by initially writing the repository files
 	if err != nil && err != storage.ErrObjectNotExist {
 		return &GoogleCloudStorage{}, err
 	}
@@ -118,11 +122,13 @@ func (backend *GoogleCloudStorage) Description() string {
 
 // AvailableSpace returns the free space on this backend.
 func (backend *GoogleCloudStorage) AvailableSpace() (uint64, error) {
-	// since google cloud storage doesn't have quota and you can store as much data as you want we return 0
-	return 0, nil
+	// since google cloud storage doesn't have quota and you can store
+	// as much data as you want we return 0
+	return 0, knoxite.ErrAvailableSpaceUnlimited
 }
 
-// CreatePath is not needed in Google Cloud Storage backend bacause paths are automatically created when writing a file.
+// CreatePath is not needed in Google Cloud Storage backend
+// bacause paths are automatically created when writing a file
 func (backend *GoogleCloudStorage) CreatePath(path string) error {
 	return nil
 }

--- a/storage/googlecloud/gcloud.go
+++ b/storage/googlecloud/gcloud.go
@@ -37,7 +37,7 @@ func init() {
 // NewBackend returns a GoogleCloudStorage backend
 // to create a storage client we need either the path to a credential JSON file set
 // via the environment variable GOOGLE_APPLICATION_CREDENTIALS="[PATH]"
-// or the path to the JSON file passed via the user parameter of the URL scheme
+// or the path to the JSON file passed via the user parameter of the URL scheme.
 func (*GoogleCloudStorage) NewBackend(URL url.URL) (knoxite.Backend, error) {
 	var credentialsPath string
 
@@ -128,7 +128,7 @@ func (backend *GoogleCloudStorage) AvailableSpace() (uint64, error) {
 }
 
 // CreatePath is not needed in Google Cloud Storage backend
-// bacause paths are automatically created when writing a file
+// because paths are automatically created when writing a file.
 func (backend *GoogleCloudStorage) CreatePath(path string) error {
 	return nil
 }

--- a/storage/s3/s3.go
+++ b/storage/s3/s3.go
@@ -107,7 +107,7 @@ func (backend *S3Storage) Description() string {
 
 // AvailableSpace returns the free space on this backend.
 func (backend *S3Storage) AvailableSpace() (uint64, error) {
-	return uint64(0), knoxite.ErrAvailableSpaceUnknown
+	return uint64(0), knoxite.ErrAvailableSpaceUnlimited
 }
 
 // LoadChunk loads a Chunk from network.


### PR DESCRIPTION
Adding a SpaceUnlimited error in backend.go, since there is no limit on Google Cloud Platform Storage products, Amazon S3 and backblaze and implements it in the storage backends.