### PR TITLE
Fix PathToUrl and enhance tests on the config system

### DIFF
--- a/cmd/knoxite/config/config_test.go
+++ b/cmd/knoxite/config/config_test.go
@@ -53,12 +53,12 @@ func TestNew(t *testing.T) {
 
 	_, err = New("foobar")
 	if err != nil {
-		t.Fatalf("Failed for 'foobar': %v", err)
+		t.Errorf("Failed creating backend for 'foobar': %v", err)
 	}
 
 	_, err = New("~/foobar")
 	if err != nil {
-		t.Fatalf("Failed here: %v", err)
+		t.Errorf("Failed creating backend for '~/foobar': %v", err)
 	}
 
 	_, err = New("c:\\foobar")

--- a/cmd/knoxite/config/config_test.go
+++ b/cmd/knoxite/config/config_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/mitchellh/go-homedir"
 )
 
 func TestNew(t *testing.T) {
@@ -56,9 +58,12 @@ func TestNew(t *testing.T) {
 		t.Errorf("Failed creating backend for 'foobar': %v", err)
 	}
 
-	_, err = New("~/foobar")
+	conf, err = New("~/foobar")
 	if err != nil {
 		t.Errorf("Failed creating backend for '~/foobar': %v", err)
+	}
+	if path, _ := homedir.Expand("~/foobar"); path != conf.url.Path {
+		t.Errorf("Expected '%s' as config path, got: %s", path, conf.url.Path)
 	}
 
 	_, err = New("c:\\foobar")

--- a/cmd/knoxite/config/config_test.go
+++ b/cmd/knoxite/config/config_test.go
@@ -66,6 +66,14 @@ func TestNew(t *testing.T) {
 		t.Errorf("Expected '%s' as config path, got: %s", path, conf.url.Path)
 	}
 
+	conf, err = New("file://~/foobar")
+	if err != nil {
+		t.Errorf("Failed creating backend for 'file://~/foobar': %v", err)
+	}
+	if path, _ := homedir.Expand("~/foobar"); path != conf.url.Path {
+		t.Errorf("Expected '%s' as config path, got: %s", path, conf.url.Path)
+	}
+
 	_, err = New("c:\\foobar")
 	if err != nil {
 		t.Errorf("Failed to create backend for valid windows url: %s", err)

--- a/cmd/knoxite/utils/utils.go
+++ b/cmd/knoxite/utils/utils.go
@@ -185,6 +185,10 @@ func PathToUrl(u string) (*url.URL, error) {
 	// This is needed in case the shell is unable to expand the path to the users
 	// home directory for inputs like these:
 	// crypto://password@~/path/to/config
-	url.Path, _ = homedir.Expand(url.Path)
+	var err error
+	url.Path, err = homedir.Expand(url.Path)
+	if err != nil {
+		return nil, err
+	}
 	return url, nil
 }

--- a/cmd/knoxite/utils/utils.go
+++ b/cmd/knoxite/utils/utils.go
@@ -177,7 +177,7 @@ func PathToUrl(u string) (*url.URL, error) {
 	// In case some other path elements have wrongfully been interpreted as Host
 	// part of the url
 	if url.Host != "" {
-		url.Path = url.Host[1:] + url.Path
+		url.Path = url.Host + url.Path
 		url.Host = ""
 	}
 


### PR DESCRIPTION
Currently the first character of the filepath will wrongly get sliced off when using config urls like `file:///foobar` or `crypto://pw@~/foo/bar`. 