### PR TITLE
Removes -p shorthand for --password flag

### DIFF
--- a/cmd/knoxite/main.go
+++ b/cmd/knoxite/main.go
@@ -2,6 +2,7 @@
  * knoxite
  *     Copyright (c) 2016-2020, Christian Muehlhaeuser <muesli@gmail.com>
  *     Copyright (c) 2020,      Nicolas Martin <penguwin@penguwin.eu>
+ *     Copyright (c) 2020,      Matthias Hartmann <mahartma@mahartma.com>
  *
  *   For license see LICENSE
  */
@@ -65,7 +66,7 @@ func main() {
 
 	RootCmd.PersistentFlags().StringVarP(&globalOpts.Repo, "repo", "r", "", "Repository directory to backup to/restore from (default: current working dir)")
 	RootCmd.PersistentFlags().StringVarP(&globalOpts.Alias, "alias", "R", "", "Repository alias to backup to/restore from")
-	RootCmd.PersistentFlags().StringVarP(&globalOpts.Password, "password", "p", "", "Password to use for data encryption")
+	RootCmd.PersistentFlags().StringVar(&globalOpts.Password, "password", "", "Password to use for data encryption")
 	RootCmd.PersistentFlags().StringVarP(&globalOpts.ConfigURL, "configURL", "C", config.DefaultPath(), "Path to the configuration file")
 
 	globalOpts.Repo = os.Getenv("KNOXITE_REPOSITORY")


### PR DESCRIPTION
This flag should not be used in production environments and a shorthand
makes it too comfortable to use.