### PR TITLE
Switch to `pelletier/go-toml` as toml library in configsystem

### DIFF
--- a/cmd/knoxite/config.go
+++ b/cmd/knoxite/config.go
@@ -13,7 +13,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/knoxite/knoxite"
 	"github.com/knoxite/knoxite/cmd/knoxite/config"
+	"github.com/knoxite/knoxite/cmd/knoxite/utils"
 	"github.com/muesli/gotable"
 	"github.com/pelletier/go-toml"
 	"github.com/spf13/cobra"
@@ -108,10 +110,10 @@ func executeConfigInit() error {
 func executeConfigAlias(alias string) error {
 	// At first check if the configuration file already exists
 	cfg.Repositories[alias] = config.RepoConfig{
-		Url: globalOpts.Repo,
-		// Compression: utils.CompressionText(knoxite.CompressionNone),
+		Url:         globalOpts.Repo,
+		Compression: utils.CompressionText(knoxite.CompressionNone),
 		// Tolerance:   0,
-		// Encryption:  utils.EncryptionText(knoxite.EncryptionAES),
+		Encryption: utils.EncryptionText(knoxite.EncryptionAES),
 	}
 
 	return cfg.Save()

--- a/cmd/knoxite/config.go
+++ b/cmd/knoxite/config.go
@@ -13,9 +13,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/BurntSushi/toml"
 	"github.com/knoxite/knoxite/cmd/knoxite/config"
 	"github.com/muesli/gotable"
+	"github.com/pelletier/go-toml"
 	"github.com/spf13/cobra"
 )
 
@@ -184,7 +184,7 @@ func executeConfigInfo() error {
 
 func executeConfigCat() error {
 	buf := new(bytes.Buffer)
-	if err := toml.NewEncoder(buf).Encode(cfg); err != nil {
+	if err := toml.NewEncoder(buf).Encode(*cfg); err != nil {
 		return err
 	}
 

--- a/cmd/knoxite/config/aesbackend.go
+++ b/cmd/knoxite/config/aesbackend.go
@@ -18,8 +18,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/BurntSushi/toml"
 	"github.com/knoxite/knoxite/cmd/knoxite/utils"
+	"github.com/pelletier/go-toml"
 	"golang.org/x/crypto/scrypt"
 )
 
@@ -117,12 +117,10 @@ func (b *AESBackend) Load(u *url.URL) (*Config, error) {
 		return config, err
 	}
 
-	_, err = toml.Decode(string(plaintext), &config)
-	if err != nil {
-		return config, err
-	}
-
-	return config, nil
+	err = toml.Unmarshal(plaintext, config)
+	config.url = u
+	config.backend = b
+	return config, err
 }
 
 // Save encrypts then saves the configuration.
@@ -142,7 +140,7 @@ func (b *AESBackend) Save(config *Config) error {
 	}
 
 	buf := new(bytes.Buffer)
-	if err := toml.NewEncoder(buf).Encode(config); err != nil {
+	if err := toml.NewEncoder(buf).Encode(*config); err != nil {
 		return err
 	}
 

--- a/cmd/knoxite/config/aesbackend_test.go
+++ b/cmd/knoxite/config/aesbackend_test.go
@@ -102,7 +102,7 @@ func TestAESBackendSave(t *testing.T) {
 	backend, _ = NewAESBackend(u)
 	err = backend.Save(c)
 	if err != nil {
-		t.Errorf("failed to save the config to %s", u)
+		t.Errorf("failed to save the config to %s: %v", u, err)
 	}
 	if !exist(absPath) {
 		t.Errorf("configuration file wasn't saved to %s", absPath)

--- a/cmd/knoxite/config/config.go
+++ b/cmd/knoxite/config/config.go
@@ -30,13 +30,13 @@ var cfgFileName = "knoxite.conf"
 
 // The RepoConfig struct contains all the default values for a a repository.
 type RepoConfig struct {
-	Url             string   `toml:"url"`
-	Compression     string   `toml:"compression"`
-	Tolerance       uint     `toml:"tolerance"`
-	Encryption      string   `toml:"encryption"`
-	Pedantic        bool     `toml:"pedantic"`
-	StoreExcludes   []string `toml:"store_excludes"`
-	RestoreExcludes []string `toml:"restore_excludes"`
+	Url             string   `toml:"url" comment:"Repository directory to backup to/restore from"`
+	Compression     string   `toml:"compression" comment:"Compressoin algo to use: none (default), flate, gzip, lzma, zlib, zstd"`
+	Tolerance       uint     `toml:"tolerance" comment:"Failure tolerance against n backend failures"`
+	Encryption      string   `toml:"encryption" comment:"Encryption algo to used: aes (default), none"`
+	Pedantic        bool     `toml:"pedantic" comment:"Stop backup operation after the first error occurred"`
+	StoreExcludes   []string `toml:"store_excludes" comment:"Specify excludes for the store operation"`
+	RestoreExcludes []string `toml:"restore_excludes" comment:"Specify excludes for the restore operation"`
 }
 
 type Config struct {

--- a/cmd/knoxite/config/filebackend.go
+++ b/cmd/knoxite/config/filebackend.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/BurntSushi/toml"
+	"github.com/pelletier/go-toml"
 )
 
 // FileBackend implements a filesystem backend for the configuration.
@@ -47,7 +47,14 @@ func (fs *FileBackend) Load(u *url.URL) (*Config, error) {
 		return config, nil
 	}
 
-	_, err = toml.DecodeFile(config.url.Path, config)
+	content, err := ioutil.ReadFile(config.url.Path)
+	if err != nil {
+		return config, err
+	}
+
+	err = toml.Unmarshal(content, config)
+	config.backend = fs
+	config.url = u
 	return config, err
 }
 
@@ -67,7 +74,7 @@ func (fs *FileBackend) Save(config *Config) error {
 	}
 
 	buf := new(bytes.Buffer)
-	if err := toml.NewEncoder(buf).Encode(config); err != nil {
+	if err := toml.NewEncoder(buf).Encode(*config); err != nil {
 		return err
 	}
 

--- a/cmd/knoxite/config/filebackend_test.go
+++ b/cmd/knoxite/config/filebackend_test.go
@@ -113,7 +113,7 @@ func TestFileSave(t *testing.T) {
 	backend = NewFileBackend()
 	err = backend.Save(c)
 	if err != nil {
-		t.Errorf("Failed to save the config to %s", u)
+		t.Errorf("Failed to save the config to %s: %v", u, err)
 	}
 	if !exist(p) {
 		t.Errorf("Configuration file wasn't saved to %s", p)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	bazil.org/fuse v0.0.0-20191225233854-3a99aca11732
 	cloud.google.com/go/storage v1.10.0
 	github.com/Azure/azure-storage-file-go v0.8.0
-	github.com/BurntSushi/toml v0.3.1
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-ini/ini v1.51.1 // indirect
@@ -25,6 +24,7 @@ require (
 	github.com/muesli/goprogressbar v0.0.0-20200829150239-abc87a99d0c4
 	github.com/muesli/gotable v0.0.0-20190807045009-bcaa6df995ab
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
+	github.com/pelletier/go-toml v1.2.0
 	github.com/pkg/sftp v1.12.0
 	github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 // indirect
 	github.com/restic/chunker v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -215,6 +215,7 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
This changes the toml library to `pelletier/go-toml` as its more actively mantained and ships with more features.

Also the default config for a repository after executing `knoxite config alias ...` now ships with comments:

```toml
[repositories]

  [repositories.fort]

    # Compressoin algo to use: none (default), flate, gzip, lzma, zlib, zstd
    compression = "none"

    # Encryption algo to used: aes (default), none
    encryption = "AES"

    # Stop backup operation after the first error occurred
    pedantic = false

    # Specify excludes for the restore operation
    restore_excludes = []

    # Specify excludes for the store operation
    store_excludes = []

    # Failure tolerance against n backend failures
    tolerance = 0

    # Repository directory to backup to/restore from
    url = "/tmp/knox"
```