### PR TITLE
Fix minor typos in 'knoxite config alias' comments

### DIFF
--- a/admin/demos/demo_tutorial.sh
+++ b/admin/demos/demo_tutorial.sh
@@ -14,7 +14,7 @@ head -c 1M </dev/urandom >data/stuff.txt
 
 # demo
 pe "mkdir backup"
-pe "knoxite -r backup/ -p password repo init"
+pe "knoxite -r backup/ --password password repo init"
 pe "export KNOXITE_REPOSITORY=backup/"
 pe "export KNOXITE_PASSWORD=password"
 pe "knoxite volume init \"Backups\" -d \"System backups\""

--- a/cmd/knoxite/config/config.go
+++ b/cmd/knoxite/config/config.go
@@ -31,9 +31,9 @@ var cfgFileName = "knoxite.conf"
 // The RepoConfig struct contains all the default values for a a repository.
 type RepoConfig struct {
 	Url             string   `toml:"url" comment:"Repository directory to backup to/restore from"`
-	Compression     string   `toml:"compression" comment:"Compressoin algo to use: none (default), flate, gzip, lzma, zlib, zstd"`
+	Compression     string   `toml:"compression" comment:"Compression algo to use: none (default), flate, gzip, lzma, zlib, zstd"`
 	Tolerance       uint     `toml:"tolerance" comment:"Failure tolerance against n backend failures"`
-	Encryption      string   `toml:"encryption" comment:"Encryption algo to used: aes (default), none"`
+	Encryption      string   `toml:"encryption" comment:"Encryption algo to use: aes (default), none"`
 	Pedantic        bool     `toml:"pedantic" comment:"Stop backup operation after the first error occurred"`
 	StoreExcludes   []string `toml:"store_excludes" comment:"Specify excludes for the store operation"`
 	RestoreExcludes []string `toml:"restore_excludes" comment:"Specify excludes for the restore operation"`


### PR DESCRIPTION
Found these 2 typos when playing around with knoxite.
Looked through a few commands to see if I can make a bit bigger PR, but haven't found any more typos.