### PR TITLE
Add initial `set-url` command

### DIFF
--- a/cmd/knoxite/repository.go
+++ b/cmd/knoxite/repository.go
@@ -78,6 +78,16 @@ var (
 			return executeRepoPack()
 		},
 	}
+	setURLCmd = &cobra.Command{
+		Use:   "set-url <new-url>",
+		Short: "set a new URL for the repository",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return fmt.Errorf("New URL is needed for changing URL")
+			}
+			return executeRepoChangeLocation(args[0])
+		},
+	}
 )
 
 func init() {
@@ -87,6 +97,7 @@ func init() {
 	repoCmd.AddCommand(repoInfoCmd)
 	repoCmd.AddCommand(repoAddCmd)
 	repoCmd.AddCommand(repoPackCmd)
+	repoCmd.AddCommand(setURLCmd)
 	RootCmd.AddCommand(repoCmd)
 }
 
@@ -216,6 +227,21 @@ func executeRepoInfo() error {
 	}
 
 	_ = tab.Print()
+	return nil
+}
+
+func executeRepoChangeLocation(newLocation string) error {
+	r, err := openRepository(globalOpts.Repo, globalOpts.Password)
+	if err != nil {
+		return err
+	}
+
+	err = r.ChangeLocation(globalOpts.Repo, newLocation)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Location successfully changed to \"%s\"\n", newLocation)
 	return nil
 }
 

--- a/repository.go
+++ b/repository.go
@@ -264,7 +264,6 @@ func (r *Repository) ChangeLocation(oldLocation, newLocation string) error {
 	oldLocation = b.Location()
 
 	// Look for backend by sanitized URL
-	fmt.Println("Looking for old Backend")
 	var oldBackendIdx int = -1
 	for idx, backend := range r.backend.Backends {
 		if (*backend).Location() == oldLocation {
@@ -281,7 +280,6 @@ func (r *Repository) ChangeLocation(oldLocation, newLocation string) error {
 	}
 
 	// Remove old backend
-	fmt.Println("Creating new backend")
 	r.backend.Backends = append(r.backend.Backends[:oldBackendIdx], r.backend.Backends[oldBackendIdx+1:]...)
 
 	// Create Backend with new URL

--- a/repository.go
+++ b/repository.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // A Repository is a collection of backup snapshots.
@@ -272,7 +273,11 @@ func (r *Repository) ChangeLocation(oldLocation, newLocation string) error {
 	}
 
 	if oldBackendIdx < 0 {
-		return fmt.Errorf("Old Location was not found")
+		locations := []string{}
+		for _, backend := range r.backend.Backends {
+			locations = append(locations, (*backend).Location())
+		}
+		return fmt.Errorf("Old Location was not found. Available Locations are: %s", strings.Join(locations, ","))
 	}
 
 	// Remove old backend


### PR DESCRIPTION
This has been tested successfully with migrating a knoxite repository from `s3s://...` to `amazons3://...`. On its own, this is not enough for us to rename the `s3(s)` backend to `minio` and `amazons3` to `s3`.

In the `set-url` command, we roughly do the following:
- open the repository at the URL passed in via the `-r` flag
- create a "fake" backend from the `-r` Flag in order to normalize the URL through the backend.
- remove the backend that matches the normalized URL
- add a new backend with the new URL
- save the repository

For Testing, I did the following:
- Create a repository using the `s3s` backend, initialize a volume and upload some files
- Through the AWS CLI, I copied the contents of the S3 buckets created by the `s3` backend to one new S3 bucket:
  - `aws s3 cp "s3://knoxite-oldbackend-test-repository/repository.knoxite" s3://jfuermann-knoxite-test-new/repository.knoxite`
  - `aws s3 cp --recursive "s3://knoxite-oldbackend-test-snapshots/" s3://jfuermann-knoxite-test-new/snapshots`
  - `aws s3 cp --recursive "s3://knoxite-oldbackend-test-chunks/" s3://jfuermann-knoxite-test-new/chunks`
- `/knoxite repo -r "s3s://s3.amazonaws.com/eu-west-1/knoxite-oldbackend-test" set-url amazons3://jfuermann-knoxite-test-new/`

After merging this PR, users can migrate their backups to the new S3 backend, the handler naming topic (`s3` vs. `amazons3`) remains unsolved.

## To Do:
- [x] Print known locations when `oldLocation` is not found
- [x] Add documentation for `set-url` to website