### PR TITLE
reduced channel leakage through deferred closing of them

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -87,7 +87,7 @@ func processChunk(password string, opts StoreOptions, jobs <-chan inputChunk, ch
 }
 
 // chunkFile divides filename into chunks of 1MiB each.
-func chunkFile(filename string, password string, opts StoreOptions) (chan ChunkResult, error) {
+func chunkFile(filename string, password string, opts StoreOptions) (<-chan ChunkResult, error) {
 	c := make(chan ChunkResult)
 
 	file, err := os.Open(filename)

--- a/cmd/knoxite/verify.go
+++ b/cmd/knoxite/verify.go
@@ -103,7 +103,7 @@ func executeVerifySnapshot(snapshotId string, opts VerifyOptions) error {
 	return nil
 }
 
-func verify(progress chan knoxite.Progress) []error {
+func verify(progress <-chan knoxite.Progress) []error {
 	var errors []error
 
 	pb := &goprogressbar.ProgressBar{Total: 1000, Width: 40}

--- a/scanner.go
+++ b/scanner.go
@@ -15,9 +15,10 @@ import (
 	"strings"
 )
 
-func findFiles(rootPath string, excludes []string) chan ArchiveResult {
+func findFiles(rootPath string, excludes []string) <-chan ArchiveResult {
 	c := make(chan ArchiveResult)
 	go func() {
+		defer close(c)
 		err := filepath.Walk(rootPath, func(path string, fi os.FileInfo, err error) error {
 			if err != nil {
 				if os.IsNotExist(err) {
@@ -93,7 +94,6 @@ func findFiles(rootPath string, excludes []string) chan ArchiveResult {
 		if err != nil {
 			c <- ArchiveResult{Archive: nil, Error: err}
 		}
-		close(c)
 	}()
 	return c
 }

--- a/verify.go
+++ b/verify.go
@@ -12,10 +12,11 @@ import (
 	"math/rand"
 )
 
-func VerifyRepo(repository Repository, percentage int) (chan Progress, error) {
+func VerifyRepo(repository Repository, percentage int) (<-chan Progress, error) {
 	prog := make(chan Progress)
 
 	go func() {
+		defer close(prog)
 		archiveToSnapshot := make(map[string]*Snapshot)
 
 		for _, volume := range repository.Volumes {
@@ -66,16 +67,16 @@ func VerifyRepo(repository Repository, percentage int) (chan Progress, error) {
 			p.CurrentItemStats.Transferred += (*snapshot.Archives[archiveKey]).Size
 			prog <- p
 		}
-		close(prog)
 	}()
 
 	return prog, nil
 }
 
-func VerifyVolume(repository Repository, volumeId string, percentage int) (chan Progress, error) {
+func VerifyVolume(repository Repository, volumeId string, percentage int) (<-chan Progress, error) {
 	prog := make(chan Progress)
 
 	go func() {
+		defer close(prog)
 		volume, err := repository.FindVolume(volumeId)
 		if err != nil {
 			prog <- newProgressError(err)
@@ -129,16 +130,16 @@ func VerifyVolume(repository Repository, volumeId string, percentage int) (chan 
 			p.CurrentItemStats.Transferred += (*snapshot.Archives[archiveKey]).Size
 			prog <- p
 		}
-		close(prog)
 	}()
 
 	return prog, nil
 }
 
-func VerifySnapshot(repository Repository, snapshotId string, percentage int) (chan Progress, error) {
+func VerifySnapshot(repository Repository, snapshotId string, percentage int) (<-chan Progress, error) {
 	prog := make(chan Progress)
 
 	go func() {
+		defer close(prog)
 		_, snapshot, err := repository.FindSnapshot(snapshotId)
 		if err != nil {
 			prog <- newProgressError(err)
@@ -178,7 +179,6 @@ func VerifySnapshot(repository Repository, snapshotId string, percentage int) (c
 			p.CurrentItemStats.Transferred += (*snapshot.Archives[archiveKey]).Size
 			prog <- p
 		}
-		close(prog)
 	}()
 
 	return prog, nil


### PR DESCRIPTION
except in
- gatherTargetInformation
- chunkFile
because in both closing is done after waiting for all
internal goroutines to finish and before the only return statement.

made clear the responsibility of the closing of the channel
through read-only return channels.