### PR TITLE
Introduce --loglevel flag and logging interface

### DIFF
--- a/cmd/knoxite/config.go
+++ b/cmd/knoxite/config.go
@@ -9,7 +9,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 

--- a/cmd/knoxite/logger.go
+++ b/cmd/knoxite/logger.go
@@ -1,0 +1,86 @@
+/*
+ * knoxite
+ *     Copyright (c) 2020-2021, Matthias Hartmann <mahartma@mahartma.com>
+ *     Copyright (c) 2020, Christian Muehlhaeuser <muesli@gmail.com>
+ *
+ *   For license see LICENSE
+ */
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/knoxite/knoxite"
+)
+
+type Logger struct {
+	VerbosityLevel knoxite.Verbosity
+	w              io.Writer
+}
+
+func NewLogger(v knoxite.Verbosity) *Logger {
+	return &Logger{
+		VerbosityLevel: v,
+		w:              os.Stdout,
+	}
+}
+
+func (l *Logger) WithWriter(w io.Writer) *Logger {
+	l.w = w
+	return l
+}
+
+func (l Logger) Warn(v ...interface{}) {
+	l.log(knoxite.LogLevelWarning, v...)
+}
+
+func (l Logger) Warnf(format string, v ...interface{}) {
+	l.logf(knoxite.LogLevelWarning, format, v...)
+}
+
+func (l Logger) Info(v ...interface{}) {
+	l.log(knoxite.LogLevelInfo, v...)
+}
+
+func (l Logger) Infof(format string, v ...interface{}) {
+	l.logf(knoxite.LogLevelInfo, format, v...)
+}
+
+func (l Logger) Debug(v ...interface{}) {
+	l.log(knoxite.LogLevelDebug, v...)
+}
+
+func (l Logger) Debugf(format string, v ...interface{}) {
+	l.logf(knoxite.LogLevelDebug, format, v...)
+}
+
+func (l Logger) Fatal(v ...interface{}) {
+	l.log(knoxite.LogLevelFatal, v...)
+	os.Exit(1)
+}
+
+func (l Logger) Fatalf(format string, v ...interface{}) {
+	l.logf(knoxite.LogLevelFatal, format, v...)
+	os.Exit(1)
+}
+
+func (l Logger) log(verbosity knoxite.Verbosity, v ...interface{}) {
+	if verbosity <= l.VerbosityLevel {
+		l.printV(verbosity, v...)
+	}
+}
+
+func (l Logger) logf(verbosity knoxite.Verbosity, format string, v ...interface{}) {
+	if verbosity <= l.VerbosityLevel {
+		l.printV(verbosity, fmt.Sprintf(format, v...))
+	}
+}
+
+func (l Logger) printV(verbosity knoxite.Verbosity, v ...interface{}) {
+	_, _ = l.w.Write([]byte(verbosity.String() + ": "))
+	_, _ = l.w.Write([]byte(fmt.Sprint(v...)))
+	_, _ = l.w.Write([]byte("\n"))
+}

--- a/cmd/knoxite/logger.go
+++ b/cmd/knoxite/logger.go
@@ -17,14 +17,14 @@ import (
 )
 
 type Logger struct {
-	VerbosityLevel knoxite.Verbosity
-	w              io.Writer
+	LogLevel knoxite.LogLevel
+	w        io.Writer
 }
 
-func NewLogger(v knoxite.Verbosity) *Logger {
+func NewLogger(l knoxite.LogLevel) *Logger {
 	return &Logger{
-		VerbosityLevel: v,
-		w:              os.Stdout,
+		LogLevel: l,
+		w:        os.Stdout,
 	}
 }
 
@@ -33,12 +33,30 @@ func (l *Logger) WithWriter(w io.Writer) *Logger {
 	return l
 }
 
+func (l Logger) Fatal(v ...interface{}) {
+	l.log(knoxite.LogLevelFatal, v...)
+	os.Exit(1)
+}
+
+func (l Logger) Fatalf(format string, v ...interface{}) {
+	l.logf(knoxite.LogLevelFatal, format, v...)
+	os.Exit(1)
+}
+
 func (l Logger) Warn(v ...interface{}) {
 	l.log(knoxite.LogLevelWarning, v...)
 }
 
 func (l Logger) Warnf(format string, v ...interface{}) {
 	l.logf(knoxite.LogLevelWarning, format, v...)
+}
+
+func (l Logger) Print(v ...interface{}) {
+	l.log(knoxite.LogLevelPrint, v...)
+}
+
+func (l Logger) Printf(format string, v ...interface{}) {
+	l.logf(knoxite.LogLevelPrint, format, v...)
 }
 
 func (l Logger) Info(v ...interface{}) {
@@ -57,30 +75,22 @@ func (l Logger) Debugf(format string, v ...interface{}) {
 	l.logf(knoxite.LogLevelDebug, format, v...)
 }
 
-func (l Logger) Fatal(v ...interface{}) {
-	l.log(knoxite.LogLevelFatal, v...)
-	os.Exit(1)
-}
-
-func (l Logger) Fatalf(format string, v ...interface{}) {
-	l.logf(knoxite.LogLevelFatal, format, v...)
-	os.Exit(1)
-}
-
-func (l Logger) log(verbosity knoxite.Verbosity, v ...interface{}) {
-	if verbosity <= l.VerbosityLevel {
-		l.printV(verbosity, v...)
+func (l Logger) log(logLevel knoxite.LogLevel, v ...interface{}) {
+	if logLevel <= l.LogLevel {
+		l.printV(logLevel, v...)
 	}
 }
 
-func (l Logger) logf(verbosity knoxite.Verbosity, format string, v ...interface{}) {
-	if verbosity <= l.VerbosityLevel {
-		l.printV(verbosity, fmt.Sprintf(format, v...))
+func (l Logger) logf(logLevel knoxite.LogLevel, format string, v ...interface{}) {
+	if logLevel <= l.LogLevel {
+		l.printV(logLevel, fmt.Sprintf(format, v...))
 	}
 }
 
-func (l Logger) printV(verbosity knoxite.Verbosity, v ...interface{}) {
-	_, _ = l.w.Write([]byte(verbosity.String() + ": "))
+func (l Logger) printV(logLevel knoxite.LogLevel, v ...interface{}) {
+	if logLevel != knoxite.LogLevelPrint {
+		_, _ = l.w.Write([]byte(logLevel.String() + ": "))
+	}
 	_, _ = l.w.Write([]byte(fmt.Sprint(v...)))
 	_, _ = l.w.Write([]byte("\n"))
 }

--- a/cmd/knoxite/main.go
+++ b/cmd/knoxite/main.go
@@ -100,10 +100,10 @@ func init() {
 }
 
 func initLogger() {
-	switch level := globalOpts.Verbose; {
-	case level == 1:
+	switch {
+	case globalOpts.Verbose == 1:
 		globalOpts.LogLevel = "Info"
-	case level >= 2:
+	case globalOpts.Verbose >= 2:
 		globalOpts.LogLevel = "Debug"
 	}
 

--- a/cmd/knoxite/main.go
+++ b/cmd/knoxite/main.go
@@ -38,7 +38,7 @@ type GlobalOptions struct {
 	Alias     string
 	Password  string
 	ConfigURL string
-	Verbose   bool
+	Verbose   int
 	LogLevel  string
 }
 
@@ -74,7 +74,7 @@ func main() {
 	RootCmd.PersistentFlags().StringVar(&globalOpts.Password, "password", "", "Password to use for data encryption")
 	RootCmd.PersistentFlags().StringVarP(&globalOpts.ConfigURL, "configURL", "C", config.DefaultPath(), "Path to the configuration file")
 	RootCmd.PersistentFlags().StringVar(&globalOpts.LogLevel, "loglevel", "Print", "Verbose output. Possible levels are Debug, Info, Warning and Fatal")
-	RootCmd.PersistentFlags().BoolVarP(&globalOpts.Verbose, "verbose", "v", false, "Verbose output on log level Info. Use --loglevel to choose between Debug, Info, Warning and Fatal")
+	RootCmd.PersistentFlags().CountVarP(&globalOpts.Verbose, "verbose", "v", "Verbose output on log level Info (-v) or Debug (-vv). Use --loglevel to choose between Debug, Info, Warning and Fatal")
 
 	globalOpts.Repo = os.Getenv("KNOXITE_REPOSITORY")
 	globalOpts.Password = os.Getenv("KNOXITE_PASSWORD")
@@ -100,8 +100,11 @@ func init() {
 }
 
 func initLogger() {
-	if globalOpts.Verbose {
+	switch level := globalOpts.Verbose; {
+	case level == 1:
 		globalOpts.LogLevel = "Info"
+	case level >= 2:
+		globalOpts.LogLevel = "Debug"
 	}
 
 	logLevel, err := utils.LogLevelFromString(globalOpts.LogLevel)

--- a/cmd/knoxite/main.go
+++ b/cmd/knoxite/main.go
@@ -101,7 +101,7 @@ func init() {
 }
 
 func initLogger() {
-	logger = *knoxite.NewLogger(utils.VerbosityTypeFromString(globalOpts.Verbosity)).
+	logger = *NewLogger(utils.VerbosityTypeFromString(globalOpts.Verbosity)).
 		WithWriter(os.Stdout)
 }
 

--- a/cmd/knoxite/utils/utils.go
+++ b/cmd/knoxite/utils/utils.go
@@ -24,9 +24,10 @@ import (
 )
 
 var (
-	ErrPasswordMismatch   = errors.New("Passwords did not match")
+	ErrPasswordMismatch   = errors.New("passwords did not match")
 	ErrEncryptionUnknown  = errors.New("unknown encryption format")
 	ErrCompressionUnknown = errors.New("unknown compression format")
+	ErrLogLevelUnknown    = errors.New("unknown log level")
 )
 
 func ReadPassword(prompt string) (string, error) {
@@ -193,16 +194,21 @@ func PathToUrl(u string) (*url.URL, error) {
 	return url, nil
 }
 
-// VerbosityTypeFromString returns the verbosity type from a user-specified string.
-func VerbosityTypeFromString(s string) knoxite.Verbosity {
+// LogLevelFromString returns the log level from a user-specified string.
+// returns log level print as default.
+func LogLevelFromString(s string) (knoxite.LogLevel, error) {
 	switch strings.ToLower(s) {
+	case "fatal":
+		return knoxite.LogLevelFatal, nil
 	case "warning":
-		return knoxite.LogLevelWarning
+		return knoxite.LogLevelWarning, nil
+	case "print":
+		return knoxite.LogLevelPrint, nil
 	case "info":
-		return knoxite.LogLevelInfo
+		return knoxite.LogLevelInfo, nil
 	case "debug":
-		return knoxite.LogLevelDebug
+		return knoxite.LogLevelDebug, nil
 	default:
-		return knoxite.LogLevelWarning
+		return knoxite.LogLevelPrint, ErrLogLevelUnknown
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -1,84 +1,20 @@
 /*
  * knoxite
- *     Copyright (c) 2020, Matthias Hartmann <mahartma@mahartma.com>
- *     Copyright (c) 2020, Christian Muehlhaeuser <muesli@gmail.com>
+ *     Copyright (c) 2021, Matthias Hartmann <mahartma@mahartma.com>
  *
  *   For license see LICENSE
  */
 
 package knoxite
 
-import (
-	"fmt"
-	"io"
-	"os"
-)
-
-type Logger struct {
-	VerbosityLevel Verbosity
-	w              io.Writer
-}
-
-func NewLogger(v Verbosity) *Logger {
-	return &Logger{
-		VerbosityLevel: v,
-		w:              os.Stdout,
-	}
-}
-
-func (l *Logger) WithWriter(w io.Writer) *Logger {
-	l.w = w
-	return l
-}
-
-func (l Logger) Warn(v ...interface{}) {
-	l.log(LogLevelWarning, v...)
-}
-
-func (l Logger) Warnf(format string, v ...interface{}) {
-	l.logf(LogLevelWarning, format, v...)
-}
-
-func (l Logger) Info(v ...interface{}) {
-	l.log(LogLevelInfo, v...)
-}
-
-func (l Logger) Infof(format string, v ...interface{}) {
-	l.logf(LogLevelInfo, format, v...)
-}
-
-func (l Logger) Debug(v ...interface{}) {
-	l.log(LogLevelDebug, v...)
-}
-
-func (l Logger) Debugf(format string, v ...interface{}) {
-	l.logf(LogLevelDebug, format, v...)
-}
-
-func (l Logger) Fatal(v ...interface{}) {
-	l.log(LogLevelFatal, v...)
-	os.Exit(1)
-}
-
-func (l Logger) Fatalf(format string, v ...interface{}) {
-	l.logf(LogLevelFatal, format, v...)
-	os.Exit(1)
-}
-
-func (l Logger) log(verbosity Verbosity, v ...interface{}) {
-	if verbosity <= l.VerbosityLevel {
-		l.printV(verbosity, v...)
-	}
-}
-
-func (l Logger) logf(verbosity Verbosity, format string, v ...interface{}) {
-	if verbosity <= l.VerbosityLevel {
-		l.printV(verbosity, fmt.Sprintf(format, v...))
-	}
-}
-
-func (l Logger) printV(verbosity Verbosity, v ...interface{}) {
-	_, _ = l.w.Write([]byte(verbosity.String() + ": "))
-	_, _ = l.w.Write([]byte(fmt.Sprint(v...)))
-	_, _ = l.w.Write([]byte("\n"))
+// Logger is used for levelled logging and verbose flag
+type Logger interface {
+	Fatal(v ...interface{})
+	Fatalf(format string, v ...interface{})
+	Warn(v ...interface{})
+	Warnf(format string, v ...interface{})
+	Info(v ...interface{})
+	Infof(format string, v ...interface{})
+	Debug(v ...interface{})
+	Debugf(format string, v ...interface{})
 }

--- a/logger.go
+++ b/logger.go
@@ -7,7 +7,7 @@
 
 package knoxite
 
-// Logger is used for levelled logging and verbose flag
+// Logger is used for levelled logging and verbose flag.
 type Logger interface {
 	Fatal(v ...interface{})
 	Fatalf(format string, v ...interface{})
@@ -18,3 +18,31 @@ type Logger interface {
 	Debug(v ...interface{})
 	Debugf(format string, v ...interface{})
 }
+
+var (
+	log Logger = NopLogger{}
+)
+
+func SetLogger(l Logger) {
+	log = l
+}
+
+// NopLogger will be used by default if no logger has been set via SetLogger().
+type NopLogger struct {
+}
+
+func (nl NopLogger) Warn(v ...interface{}) {}
+
+func (nl NopLogger) Warnf(format string, v ...interface{}) {}
+
+func (nl NopLogger) Info(v ...interface{}) {}
+
+func (nl NopLogger) Infof(format string, v ...interface{}) {}
+
+func (nl NopLogger) Debug(v ...interface{}) {}
+
+func (nl NopLogger) Debugf(format string, v ...interface{}) {}
+
+func (nl NopLogger) Fatal(v ...interface{}) {}
+
+func (nl NopLogger) Fatalf(format string, v ...interface{}) {}

--- a/logger.go
+++ b/logger.go
@@ -13,6 +13,8 @@ type Logger interface {
 	Fatalf(format string, v ...interface{})
 	Warn(v ...interface{})
 	Warnf(format string, v ...interface{})
+	Print(v ...interface{})
+	Printf(format string, v ...interface{})
 	Info(v ...interface{})
 	Infof(format string, v ...interface{})
 	Debug(v ...interface{})
@@ -27,13 +29,21 @@ func SetLogger(l Logger) {
 	log = l
 }
 
-// NopLogger will be used by default if no logger has been set via SetLogger().
+// The quiet NopLogger will be used by default if no logger has been set via SetLogger().
 type NopLogger struct {
 }
+
+func (nl NopLogger) Fatal(v ...interface{}) {}
+
+func (nl NopLogger) Fatalf(format string, v ...interface{}) {}
 
 func (nl NopLogger) Warn(v ...interface{}) {}
 
 func (nl NopLogger) Warnf(format string, v ...interface{}) {}
+
+func (nl NopLogger) Print(v ...interface{}) {}
+
+func (nl NopLogger) Printf(format string, v ...interface{}) {}
 
 func (nl NopLogger) Info(v ...interface{}) {}
 
@@ -42,7 +52,3 @@ func (nl NopLogger) Infof(format string, v ...interface{}) {}
 func (nl NopLogger) Debug(v ...interface{}) {}
 
 func (nl NopLogger) Debugf(format string, v ...interface{}) {}
-
-func (nl NopLogger) Fatal(v ...interface{}) {}
-
-func (nl NopLogger) Fatalf(format string, v ...interface{}) {}

--- a/loglevel.go
+++ b/loglevel.go
@@ -8,16 +8,17 @@
 
 package knoxite
 
-// verbosity levels for logging.
-type Verbosity int
+// log levels for logging.
+type LogLevel int
 
 const (
 	LogLevelFatal = iota
 	LogLevelWarning
+	LogLevelPrint
 	LogLevelInfo
 	LogLevelDebug
 )
 
-func (v Verbosity) String() string {
-	return [...]string{"Fatal", "Warning", "Info", "Debug"}[v]
+func (l LogLevel) String() string {
+	return [...]string{"Fatal", "Warning", "Print", "Info", "Debug"}[l]
 }

--- a/verbosity.go
+++ b/verbosity.go
@@ -8,7 +8,7 @@
 
 package knoxite
 
-// verbosity levels for logging
+// verbosity levels for logging.
 type Verbosity int
 
 const (

--- a/verbosity.go
+++ b/verbosity.go
@@ -8,6 +8,7 @@
 
 package knoxite
 
+// verbosity levels for logging
 type Verbosity int
 
 const (


### PR DESCRIPTION
This PR introduces a --loglevel flag to let the user set the level of verbose output to Fatal, Warn, Info or Debug.
The -v flag will only set the log level to "Info".
There is also a new "Print" log level to replace fmt for normal output, a logger interface and a NopLogger for quiet output if no logger has been set for the knoxite library.

There already is a PR to update the website: [Website PR 69](https://github.com/knoxite/website/pull/69)