### PR TITLE
Don't segfault when encountering permission denied errors

### DIFF
--- a/cmd/knoxite/store.go
+++ b/cmd/knoxite/store.go
@@ -195,7 +195,7 @@ func store(repository *knoxite.Repository, chunkIndex *knoxite.ChunkIndex, snaps
 
 	fmt.Printf("\nSnapshot %s created: %s\n", snapshot.ID, snapshot.Stats.String())
 	for file, err := range errs {
-		fmt.Printf("'%s': failed to store: %v\n", file, err)
+		fmt.Printf("Failed to store '%s': %v\n", file, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #189 

The bug was caused by accessing a `nil` value from `ArchiveResult<Archive, Error>` in order to get the `Archive.Path` when encountering errors during file collection (such as permission denied) for snapshot creation in `snapshot.go`.

I decided to always include a set `Archive` when sending a `ArchiveResult` into the channel in `scanner.go`. This is for the following reasons:
- We need it to report to the user which file path exactly encountered issues during snapshot creation.
- We don't want to return any other error value than `nil` or `filepath/fs.SkipDir` in our `WalkFunk` implementation for `filepath.Walk` as this will cause Walk to [stop walking the entire tree](https://pkg.go.dev/path/filepath#WalkFunc). The behavior when to stop is defined via the `--pedantic` flag and set off by returning non-nil `Error` values in `ArchiveResult`.

This PR also fixes a another segfault when entering invalid `exclude` patterns such as `-x "\\"`. *knoxite* will now immediately exit regardless of `--pedantic` with a message:
```
Failed to store '/tmp/knoxite-189/foo': Invalid exclude filter '\': syntax error in pattern
```
as the pattern will never match and is probably an unintended error/typo from the user.