### PR TITLE
Fix docs GitHub actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,4 +21,5 @@ jobs:
       - name: Git Auto Commit
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
+          token: ${{ secrets.PAT }}
           commit_message: "docs: update cmd docs"

--- a/docs/knoxite-cat.1
+++ b/docs/knoxite-cat.1
@@ -28,7 +28,7 @@ The cat command prints a file on the standard output
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-clone.1
+++ b/docs/knoxite-clone.1
@@ -52,7 +52,7 @@ The clone command clones an existing snapshot and adds a file or directory
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-config-alias.1
+++ b/docs/knoxite-config-alias.1
@@ -28,7 +28,7 @@ The set command adds an alias for the storage backend url to a repository
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-config-cat.1
+++ b/docs/knoxite-config-cat.1
@@ -28,7 +28,7 @@ The cat command displays the configuration file on stdout
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-config-convert.1
+++ b/docs/knoxite-config-convert.1
@@ -28,7 +28,7 @@ The convert command translates between several configuration backends
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-config-info.1
+++ b/docs/knoxite-config-info.1
@@ -28,7 +28,7 @@ The info command displays information about the configuration file on stdout
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-config-init.1
+++ b/docs/knoxite-config-init.1
@@ -28,7 +28,7 @@ The init command initializes a new configuration file
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-config-set.1
+++ b/docs/knoxite-config-set.1
@@ -28,7 +28,7 @@ The set command lets you set configuration values for an alias
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-config.1
+++ b/docs/knoxite-config.1
@@ -28,7 +28,7 @@ The config command manages the knoxite configuration
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-docs.1
+++ b/docs/knoxite-docs.1
@@ -28,7 +28,7 @@ Generates documentation as manpages to the given directory path
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-ls.1
+++ b/docs/knoxite-ls.1
@@ -28,7 +28,7 @@ The ls command lists all files stored in a snapshot
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-mount.1
+++ b/docs/knoxite-mount.1
@@ -28,7 +28,7 @@ The mount command mounts a repository read\-only to a given directory
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-repo-add.1
+++ b/docs/knoxite-repo-add.1
@@ -28,7 +28,7 @@ The add command adds another storage backend to a repository
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-repo-cat.1
+++ b/docs/knoxite-repo-cat.1
@@ -28,7 +28,7 @@ The cat command displays the internal repository information as JSON
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-repo-info.1
+++ b/docs/knoxite-repo-info.1
@@ -28,7 +28,7 @@ The info command displays the repository status \& information
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-repo-init.1
+++ b/docs/knoxite-repo-init.1
@@ -28,7 +28,7 @@ The init command initializes a new repository
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-repo-pack.1
+++ b/docs/knoxite-repo-pack.1
@@ -28,7 +28,7 @@ The pack command deletes all unused data chunks from storage
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-repo-passwd.1
+++ b/docs/knoxite-repo-passwd.1
@@ -28,7 +28,7 @@ The passwd command changes the password of a repository
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-repo.1
+++ b/docs/knoxite-repo.1
@@ -28,7 +28,7 @@ The repo command manages repositories
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-restore.1
+++ b/docs/knoxite-restore.1
@@ -36,7 +36,7 @@ The restore command restores a snapshot to a directory
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-snapshot-list.1
+++ b/docs/knoxite-snapshot-list.1
@@ -28,7 +28,7 @@ The list command lists all snapshots stored in a volume
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-snapshot-remove.1
+++ b/docs/knoxite-snapshot-remove.1
@@ -28,7 +28,7 @@ The remove command deletes a snapshot from a volume
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-snapshot.1
+++ b/docs/knoxite-snapshot.1
@@ -28,7 +28,7 @@ The snapshot command manages snapshots
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-store.1
+++ b/docs/knoxite-store.1
@@ -52,7 +52,7 @@ The store command creates a snapshot of a file or directory
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-verify.1
+++ b/docs/knoxite-verify.1
@@ -32,7 +32,7 @@ verify a repo, volume or snapshot
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-volume-init.1
+++ b/docs/knoxite-volume-init.1
@@ -32,7 +32,7 @@ The init command initializes a new volume
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-volume-list.1
+++ b/docs/knoxite-volume-list.1
@@ -28,7 +28,7 @@ The list command lists all volumes stored in a repository
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-volume-remove.1
+++ b/docs/knoxite-volume-remove.1
@@ -28,7 +28,7 @@ The remove command removes a volume from a repository
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite-volume.1
+++ b/docs/knoxite-volume.1
@@ -28,7 +28,7 @@ The volume command manages volumes
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP

--- a/docs/knoxite.1
+++ b/docs/knoxite.1
@@ -23,7 +23,7 @@ Complete documentation is available at https://github.com/knoxite/knoxite
 	Repository alias to backup to/restore from
 
 .PP
-\fB\-C\fP, \fB\-\-configURL\fP="/home/raschaady/.config/knoxite/knoxite.conf"
+\fB\-C\fP, \fB\-\-configURL\fP="/home/runner/.config/knoxite/knoxite.conf"
 	Path to the configuration file
 
 .PP


### PR DESCRIPTION
Please insert a PAT to the repository, so docs action doesn't crash anymore. The line added should take the PAT from the repo and allows the github action to auto commit the man docs to the repository. Thanks.