### PR TITLE
Make error messages lowercase

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -64,11 +64,11 @@ type Backend interface {
 
 // Error declarations.
 var (
-	ErrRepositoryExists        = errors.New("Repository seems to already exist")
-	ErrInvalidRepositoryURL    = errors.New("Invalid repository url specified")
-	ErrAvailableSpaceUnknown   = errors.New("Available space is unknown or undefined")
-	ErrAvailableSpaceUnlimited = errors.New("Available space is unlimited")
-	ErrInvalidUsername         = errors.New("Username wrong or missing")
+	ErrRepositoryExists        = errors.New("repository seems to already exist")
+	ErrInvalidRepositoryURL    = errors.New("invalid repository url specified")
+	ErrAvailableSpaceUnknown   = errors.New("available space is unknown or undefined")
+	ErrAvailableSpaceUnlimited = errors.New("available space is unlimited")
+	ErrInvalidUsername         = errors.New("username wrong or missing")
 
 	backends = []BackendFactory{}
 )

--- a/backendmanager.go
+++ b/backendmanager.go
@@ -22,15 +22,15 @@ type BackendManager struct {
 
 // Error declarations.
 var (
-	ErrLoadChunkFailed       = errors.New("Unable to load chunk from any storage backend")
-	ErrLoadSnapshotFailed    = errors.New("Unable to load snapshot from any storage backend")
-	ErrLoadChunkIndexFailed  = errors.New("Unable to load chunk-index from any storage backend")
-	ErrLoadRepositoryFailed  = errors.New("Unable to load repository from any storage backend")
-	ErrDeleteChunkFailed     = errors.New("Unable to delete chunk from any storage backend")
-	ErrStoreChunkFailed      = errors.New("Storing chunk failed")
-	ErrStoreSnapshotFailed   = errors.New("Storing snapshot failed")
-	ErrStoreChunkIndexFailed = errors.New("Storing chunk-index failed")
-	ErrStoreRepositoryFailed = errors.New("Storing repository failed")
+	ErrLoadChunkFailed       = errors.New("unable to load chunk from any storage backend")
+	ErrLoadSnapshotFailed    = errors.New("unable to load snapshot from any storage backend")
+	ErrLoadChunkIndexFailed  = errors.New("unable to load chunk-index from any storage backend")
+	ErrLoadRepositoryFailed  = errors.New("unable to load repository from any storage backend")
+	ErrDeleteChunkFailed     = errors.New("unable to delete chunk from any storage backend")
+	ErrStoreChunkFailed      = errors.New("storing chunk failed")
+	ErrStoreSnapshotFailed   = errors.New("storing snapshot failed")
+	ErrStoreChunkIndexFailed = errors.New("storing chunk-index failed")
+	ErrStoreRepositoryFailed = errors.New("storing repository failed")
 )
 
 // AddBackend adds a backend.

--- a/cmd/knoxite/config.go
+++ b/cmd/knoxite/config.go
@@ -150,7 +150,7 @@ func executeConfigSet(option string, values []string) error {
 	// The first part should be the repos alias
 	repo, ok := cfg.Repositories[strings.ToLower(parts[0])]
 	if !ok {
-		return fmt.Errorf("No alias with name %s found", parts[0])
+		return fmt.Errorf("no alias with name %s found", parts[0])
 	}
 
 	opt := strings.ToLower(parts[1])
@@ -164,7 +164,7 @@ func executeConfigSet(option string, values []string) error {
 	case "tolerance":
 		tol, err := strconv.Atoi(values[0])
 		if err != nil {
-			return fmt.Errorf("Failed to convert %s to uint for the fault tolerance option: %v", opt, err)
+			return fmt.Errorf("failed to convert %s to uint for the fault tolerance option: %v", opt, err)
 		}
 		repo.Tolerance = uint(tol)
 	case "store_excludes":
@@ -179,7 +179,7 @@ func executeConfigSet(option string, values []string) error {
 		repo.Pedantic = b
 
 	default:
-		return fmt.Errorf("Unknown configuration option: %s", opt)
+		return fmt.Errorf("unknown configuration option: %s", opt)
 	}
 	cfg.Repositories[strings.ToLower(parts[0])] = repo
 

--- a/cmd/knoxite/repository.go
+++ b/cmd/knoxite/repository.go
@@ -106,7 +106,7 @@ func executeRepoInit() error {
 
 	r, err := newRepository(globalOpts.Repo, globalOpts.Password)
 	if err != nil {
-		return fmt.Errorf("Creating repository at %s failed: %v", globalOpts.Repo, err)
+		return fmt.Errorf("creating repository at %s failed: %v", globalOpts.Repo, err)
 	}
 
 	fmt.Printf("Created new repository at %s\n", (*r.BackendManager().Backends[0]).Location())

--- a/cmd/knoxite/volume.go
+++ b/cmd/knoxite/volume.go
@@ -99,7 +99,7 @@ func executeVolumeInit(name, description string) error {
 
 	err = repository.AddVolume(vol)
 	if err != nil {
-		return fmt.Errorf("Creating volume %s failed: %v", name, err)
+		return fmt.Errorf("creating volume %s failed: %v", name, err)
 	}
 
 	annotation := "Name: " + vol.Name

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -17,28 +17,28 @@ func authPath(w http.ResponseWriter, r *http.Request) (string, error) {
 	auth, _, ok := r.BasicAuth()
 	if !ok {
 		w.WriteHeader(http.StatusUnauthorized)
-		return "", errors.New("Security alert: no auth set")
+		return "", errors.New("security alert: no auth set")
 	}
 
 	// check for relative path attacks
 	if strings.Contains(r.URL.Path, ".."+string(os.PathSeparator)) {
 		w.WriteHeader(http.StatusUnauthorized)
-		return "", errors.New("Security alert: url path tampering")
+		return "", errors.New("security alert: url path tampering")
 	}
 	if strings.Contains(auth, ".."+string(os.PathSeparator)) {
 		w.WriteHeader(http.StatusUnauthorized)
-		return "", errors.New("Security alert: auth code tampering")
+		return "", errors.New("security alert: auth code tampering")
 	}
 
 	dir := filepath.Join(storagePath, auth)
 	src, err := os.Stat(dir)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
-		return "", errors.New("Invalid auth code: unknown user")
+		return "", errors.New("invalid auth code: unknown user")
 	}
 	if !src.IsDir() {
 		w.WriteHeader(http.StatusUnauthorized)
-		return "", errors.New("Invalid auth code: not a dir")
+		return "", errors.New("invalid auth code: not a dir")
 	}
 
 	return dir, nil

--- a/compression.go
+++ b/compression.go
@@ -64,7 +64,7 @@ func (c Compressor) Process(data []byte) ([]byte, error) {
 		return []byte{}, err
 	}
 	if n != len(data) {
-		return []byte{}, fmt.Errorf("Could not write all data to compressor")
+		return []byte{}, fmt.Errorf("could not write all data to compressor")
 	}
 	err = w.Close()
 	if err != nil {

--- a/encryption.go
+++ b/encryption.go
@@ -22,7 +22,7 @@ const (
 
 // Error declarations.
 var (
-	ErrInvalidPassword = errors.New("Empty password not permitted")
+	ErrInvalidPassword = errors.New("empty password not permitted")
 )
 
 // Encryptor is a pipeline processor that encrypts data.

--- a/progress_test.go
+++ b/progress_test.go
@@ -31,7 +31,7 @@ func TestProgressTransferSpeed(t *testing.T) {
 }
 
 func TestProgressError(t *testing.T) {
-	p := newProgressError(errors.New("TestError"))
+	p := newProgressError(errors.New("testError"))
 	if p.Error == nil {
 		t.Errorf("Expected error, got %s", p.Error)
 	}

--- a/repository.go
+++ b/repository.go
@@ -33,11 +33,11 @@ const (
 
 // Error declarations.
 var (
-	ErrRepositoryIncompatible  = errors.New("The repository is not compatible with this version of Knoxite")
-	ErrOpenRepositoryFailed    = errors.New("Wrong password or corrupted repository")
-	ErrVolumeNotFound          = errors.New("Volume not found")
-	ErrSnapshotNotFound        = errors.New("Snapshot not found")
-	ErrGenerateRandomKeyFailed = errors.New("Failed to generate a random encryption key for new repository")
+	ErrRepositoryIncompatible  = errors.New("the repository is not compatible with this version of Knoxite")
+	ErrOpenRepositoryFailed    = errors.New("wrong password or corrupted repository")
+	ErrVolumeNotFound          = errors.New("volume not found")
+	ErrSnapshotNotFound        = errors.New("snapshot not found")
+	ErrGenerateRandomKeyFailed = errors.New("failed to generate a random encryption key for new repository")
 )
 
 // NewRepository returns a new repository.

--- a/storage/amazons3/backend_test.go
+++ b/storage/amazons3/backend_test.go
@@ -226,7 +226,7 @@ var _ = Describe("DeleteFile", func() {
 		BeforeEach(func() {
 			backend = &AmazonS3StorageBackend{
 				service: &mockS3Client{
-					deleteObjectError: awserr.New("NotFound", "Foobar", fmt.Errorf("NotFound")),
+					deleteObjectError: awserr.New("NotFound", "Foobar", fmt.Errorf("notFound")),
 				},
 			}
 			err = backend.DeleteFile("asdf")

--- a/storage/ftp/ftp.go
+++ b/storage/ftp/ftp.go
@@ -34,7 +34,7 @@ type FTPStorage struct {
 
 // Error declarations.
 var (
-	ErrInvalidAuthentication = errors.New("Wrong Username or Password")
+	ErrInvalidAuthentication = errors.New("wrong Username or Password")
 )
 
 func init() {

--- a/storage/googlecloud/gcloud.go
+++ b/storage/googlecloud/gcloud.go
@@ -47,7 +47,7 @@ func (*GoogleCloudStorage) NewBackend(URL url.URL) (knoxite.Backend, error) {
 		var credentialsSet bool
 		credentialsPath, credentialsSet = os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS")
 		if !credentialsSet {
-			return &GoogleCloudStorage{}, errors.New("No valid JSON credentials file provided.")
+			return &GoogleCloudStorage{}, errors.New("no valid JSON credentials file provided.")
 		}
 	} else {
 		credentialsPath = URL.User.Username()

--- a/storage/s3/s3.go
+++ b/storage/s3/s3.go
@@ -45,7 +45,7 @@ func (*S3Storage) NewBackend(URL url.URL) (knoxite.Backend, error) {
 	case "s3s":
 		ssl = true
 	default:
-		return &S3Storage{}, errors.New("Invalid s3 url scheme")
+		return &S3Storage{}, errors.New("invalid s3 url scheme")
 	}
 
 	var username, pw string

--- a/storage/webdav/webdav.go
+++ b/storage/webdav/webdav.go
@@ -26,7 +26,7 @@ type WebDAVStorage struct {
 
 // Error declarations.
 var (
-	ErrInvalidAuthentication = errors.New("Wrong Username or Password")
+	ErrInvalidAuthentication = errors.New("wrong Username or Password")
 )
 
 func init() {

--- a/storage_filesystem.go
+++ b/storage_filesystem.go
@@ -127,7 +127,7 @@ func (backend StorageFilesystem) InitRepository() error {
 			return ErrRepositoryExists
 			/*
 				if !stat.IsDir() {
-					return &os.PathError{Op: "create", Path: path, Err: errors.New("Repository path contains an invalid file")}
+					return &os.PathError{Op: "create", Path: path, Err: errors.New("repository path contains an invalid file")}
 				}
 			*/
 		}

--- a/verify_test.go
+++ b/verify_test.go
@@ -34,7 +34,7 @@ var verifyTestCases = []struct {
 			return err
 		}
 		if len(layer0) == 0 {
-			return errors.New("Files expected")
+			return errors.New("files expected")
 		}
 
 		layer1, err := ioutil.ReadDir(filepath.Join(dir, "chunks", layer0[0].Name()))
@@ -43,7 +43,7 @@ var verifyTestCases = []struct {
 		}
 
 		if len(layer1) == 0 {
-			return errors.New("Files expected")
+			return errors.New("files expected")
 		}
 
 		layer2, err := ioutil.ReadDir(filepath.Join(dir, "chunks", layer0[0].Name(), layer1[0].Name()))
@@ -52,7 +52,7 @@ var verifyTestCases = []struct {
 		}
 
 		if len(layer2) == 0 {
-			return errors.New("Files expected")
+			return errors.New("files expected")
 		}
 
 		os.Remove(filepath.Join(dir, "chunks", layer0[0].Name(), layer1[0].Name(), layer2[0].Name()))


### PR DESCRIPTION
Make error messages lowercase to make the linter happy and achieve consistency with logging messages.