### PR TITLE
Fixes wrong mtime of folders when restoring backup

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -187,6 +187,10 @@ func DecodeArchive(progress chan<- Progress, repository Repository, arc Archive,
 		if err != nil {
 			return err
 		}
+		err = os.Chtimes(path, time.Now().Local(), time.Unix(arc.ModTime, 0))
+		if err != nil {
+			return err
+		}
 		p.TotalStatistics.Dirs++
 		progress <- p
 	} else if arc.Type == SymLink {


### PR DESCRIPTION
Sets **atime** of Folder to **current time** and **mtime** to Archive's **ModTime**. Worked at least for me.

TODOs for review:
- [x] Check, if this is a valid fix for the issue
- [x] ~~Check, if this line needs a fix as well: [decode.go:211](https://github.com/knoxite/knoxite/blob/4388cb082e4de33ab0fb6960c39ed3310c70f40e/decode.go#L211) (currently only implemented for good measure)~~ Moved to #221 

closes #219 