### PR TITLE
Adds rename volume command

### DIFF
--- a/volume.go
+++ b/volume.go
@@ -33,6 +33,11 @@ func NewVolume(name, description string) (*Volume, error) {
 	return &vol, nil
 }
 
+func (v *Volume) RenameVolume(name string) error {
+	v.Name = name
+	return nil
+}
+
 // AddSnapshot adds a snapshot to a volume.
 func (v *Volume) AddSnapshot(id string) error {
 	v.Snapshots = append(v.Snapshots, id)


### PR DESCRIPTION
This adds a volume rename subcommand.

# Usage

```
knoxite -r [repo_url] volume rename [volume_id] [volume_new_name]
e.g.
knoxite -r /tmp/knoxite volume rename dc500f37 "My new volume name"
```